### PR TITLE
Fix missing S7 module export

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod value;
 pub mod signal;
 pub mod block;
 pub mod config;
+pub mod s7;
 pub mod engine;
 pub mod mqtt;
 


### PR DESCRIPTION
## Summary
- expose the S7 module from the crate root

## Testing
- `cargo test` *(fails: unknown rename rule and S7 crate errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856537668b8832c89524c9f2968ee37