### PR TITLE
Fix s7_test binary compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rumqttc = "0.24"
 chrono = "0.4"
 # S7 communication library
 s7 = "0.1.9"
+clap = { version = "4", features = ["derive"] }
 
 [profile.release]
 lto = true

--- a/src/bin/s7_test.rs
+++ b/src/bin/s7_test.rs
@@ -95,17 +95,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .init();
 
     let cli = Cli::parse();
-    
-    match cli.command {
+
+    match &cli.command {
         Commands::Connect => test_connection(&cli).await?,
         Commands::Read { area, db, address, data_type, bit } => {
-            test_read(&cli, area, db, address, data_type, bit).await?
+            test_read(&cli, area.clone(), *db, *address, data_type.clone(), *bit).await?
         },
         Commands::Write { area, db, address, data_type, bit, value } => {
-            test_write(&cli, area, db, address, data_type, bit, value).await?
+            test_write(&cli, area.clone(), *db, *address, data_type.clone(), *bit, value.clone()).await?
         },
         Commands::Monitor { config } => {
-            monitor_values(&cli, config).await?
+            monitor_values(&cli, config.clone()).await?
         },
     }
     
@@ -169,7 +169,7 @@ async fn test_read(
         bit,
         direction: Direction::Read,
     };
-    
+
     let config = S7Config {
         ip: cli.ip.clone(),
         rack: cli.rack,
@@ -177,15 +177,15 @@ async fn test_read(
         connection_type: "PG".to_string(),
         poll_interval_ms: 1000,
         timeout_ms: 5000,
-        mappings: vec![mapping],
+        mappings: vec![mapping.clone()],
     };
     
     let bus = SignalBus::new();
     let connector = S7Connector::new(config, bus.clone())?;
     connector.connect().await?;
-    
+
     // Do one read cycle
-    connector.read_mapping(&connector.mappings[0]).await?;
+    connector.read_mapping(&mapping).await?;
     
     let value = bus.get("test_signal")?;
     info!("✓ Read value: {}", value);
@@ -235,7 +235,7 @@ async fn test_write(
         connection_type: "PG".to_string(),
         poll_interval_ms: 1000,
         timeout_ms: 5000,
-        mappings: vec![mapping],
+        mappings: vec![mapping.clone()],
     };
     
     let bus = SignalBus::new();
@@ -243,9 +243,9 @@ async fn test_write(
     
     let connector = S7Connector::new(config, bus)?;
     connector.connect().await?;
-    
+
     // Do one write cycle
-    connector.write_mapping(&connector.mappings[0]).await?;
+    connector.write_mapping(&mapping).await?;
     
     info!("✓ Successfully wrote value");
     

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,5 +15,6 @@ pub use signal::SignalBus;
 pub use config::Config;
 pub use engine::{Engine, EngineStats};
 pub use mqtt::{MqttHandler, MqttMessage};
+pub use s7::S7Connector;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/s7.rs
+++ b/src/s7.rs
@@ -194,7 +194,7 @@ impl S7Connector {
         info!("S7 connector stopped");
     }
 
-    async fn read_mapping(&self, mapping: &S7Mapping) -> Result<()> {
+    pub async fn read_mapping(&self, mapping: &S7Mapping) -> Result<()> {
         let mut guard = self.client.lock().await;
         let client = guard.as_mut().ok_or_else(|| PlcError::Config("Not connected".into()))?;
         let size = mapping.data_type.size();
@@ -254,7 +254,7 @@ impl S7Connector {
         Ok(())
     }
 
-    async fn write_mapping(&self, mapping: &S7Mapping) -> Result<()> {
+    pub async fn write_mapping(&self, mapping: &S7Mapping) -> Result<()> {
         // Get value from signal bus
         let value = match self.bus.get(&mapping.signal) {
             Ok(v) => v,


### PR DESCRIPTION
## Summary
- add missing clap dependency
- export `S7Connector` from the crate root
- expose `read_mapping` and `write_mapping` for testing
- adjust `s7_test` to avoid private fields and borrow issues

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6856575f6ebc832c902acc0978f40dd6