### PR TITLE
Fix Clap option collision

### DIFF
--- a/src/bin/s7_test.rs
+++ b/src/bin/s7_test.rs
@@ -46,7 +46,7 @@ enum Commands {
         address: u32,
         
         /// Data type (bool, byte, word, int, dint, real)
-        #[arg(short, long)]
+        #[arg(short = 't', long)]
         data_type: String,
         
         /// Bit offset (for bool)
@@ -69,7 +69,7 @@ enum Commands {
         address: u32,
         
         /// Data type (bool, byte, word, int, dint, real)
-        #[arg(short, long)]
+        #[arg(short = 't', long)]
         data_type: String,
         
         /// Bit offset (for bool)


### PR DESCRIPTION
## Summary
- fix duplicate short option names in `s7_test` CLI

## Testing
- `cargo check --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6856ee8b82e4832cb52c1856a0757f17