### PR TITLE
Fix manifest parse error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,4 +85,4 @@ panic = "abort"
 default = ["s7-support", "history"]
 s7-support = []
 history = []
-advanced-storage = ["rocksdb", "clickhouse", "object_store", "aws-sdk-s3", "aws-config", "zstd", "lz4", "datafusion"]
+advanced-storage = ["rocksdb", "clickhouse", "object_store", "aws-sdk-s3", "aws-config", "zstd", "lz4"]


### PR DESCRIPTION
## Summary
- remove leftover `datafusion` feature that isn't a dependency

## Testing
- `cargo check` *(fails: no matching version for `arrow`)*

------
https://chatgpt.com/codex/tasks/task_e_6859742af240832cb0b2c869b0ed7f44