### PR TITLE
Fix compile errors in history manager and main

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -15,7 +15,7 @@ use parquet::arrow::ArrowWriter;
 use parquet::file::properties::WriterProperties;
 use parquet::basic::Compression;
 use std::fs::{self, File};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HistoryConfig {
@@ -257,7 +257,7 @@ impl HistoryManager {
         Ok(())
     }
 
-    async fn record_signal_change(&self, name: &str, value: Value) {
+    async fn record_signal_change(&mut self, name: &str, value: Value) {
         let now = Instant::now();
         let timestamp = Utc::now();
         
@@ -400,7 +400,7 @@ impl HistoryManager {
         Ok(())
     }
 
-    fn close_writer(&self, mut writer: ParquetWriter) -> Result<()> {
+    fn close_writer(&self, writer: ParquetWriter) -> Result<()> {
         writer.writer.close()
             .map_err(|e| PlcError::Io(std::io::Error::new(
                 std::io::ErrorKind::Other,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use tracing_subscriber;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use std::net::SocketAddr;
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
     // Initialize Prometheus metrics endpoint
     let metrics_addr: SocketAddr = "0.0.0.0:9090".parse().unwrap();
     PrometheusBuilder::new()
-        .listen_address(metrics_addr)
+        .with_http_listener(metrics_addr)
         .install()
         .expect("Failed to install Prometheus recorder");
 
@@ -51,7 +51,7 @@ async fn main() -> Result<()> {
         let mut history_manager = HistoryManager::new(history_config, bus.clone())?;
         history_manager.set_signal_change_channel(history_rx);
         
-        Some(tokio::spawn(async move {
+        Some(tokio::task::spawn_local(async move {
             if let Err(e) = history_manager.run().await {
                 error!("History manager error: {}", e);
             }


### PR DESCRIPTION
## Summary
- remove unused `Path` import in `history.rs`
- allow `record_signal_change` to take `&mut self`
- drop unnecessary `mut` in `close_writer`
- update Prometheus builder usage and switch to single-thread runtime
- spawn history manager using `spawn_local`

## Testing
- `cargo check -q`
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_6859767ee304832cbc5c4d2c0f1eb2ae