### PR TITLE
Remove unused fields to clear warnings

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -147,7 +147,6 @@ pub struct HistoryManager {
     running: Arc<RwLock<bool>>,
     current_writer: Option<ParquetWriter>,
     schema: Arc<Schema>,
-    start_instant: Instant,
 }
 
 impl HistoryManager {
@@ -174,7 +173,6 @@ impl HistoryManager {
             running: Arc::new(RwLock::new(false)),
             current_writer: None,
             schema,
-            start_instant: Instant::now(),
         })
     }
 

--- a/src/twilio.rs
+++ b/src/twilio.rs
@@ -77,8 +77,6 @@ struct MessageResponse {
     sid: String,
     status: String,
     #[serde(default)]
-    error_code: Option<String>,
-    #[serde(default)]
     error_message: Option<String>,
 }
 
@@ -87,8 +85,6 @@ struct MessageResponse {
 struct CallResponse {
     sid: String,
     status: String,
-    #[serde(default)]
-    error_code: Option<String>,
     #[serde(default)]
     error_message: Option<String>,
 }


### PR DESCRIPTION
## Summary
- remove unused `error_code` fields from Twilio API structs
- drop unused `start_instant` from `HistoryManager`

## Testing
- `cargo test --quiet`
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_68597ae047f0832cb226b31983436e87