### PR TITLE
Fix artifact upload action

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -171,7 +171,7 @@ jobs:
 
       - name: Upload test artifacts
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: smoke-test-logs
           path: |


### PR DESCRIPTION
## Summary
- bump `actions/upload-artifact` from v3 to v4 in smoke test workflow

## Testing
- `cargo check`
- `cargo test -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_685addcdaa54832c8c8b2eed750dff33