### PR TITLE
Fix remote storage imports

### DIFF
--- a/src/storage/manager.rs
+++ b/src/storage/manager.rs
@@ -1,6 +1,8 @@
 // src/storage/manager.rs - Complete implementation
 use super::*;
 use crate::{error::*, value::Value, signal::SignalBus};
+use super::remote::{RemoteStorage, S3Storage};
+use super::clickhouse::ClickHouseStorage;
 use std::sync::Arc;
 use parking_lot::RwLock;
 use tokio::sync::{mpsc, Mutex};

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -3,6 +3,7 @@ pub mod local;
 pub mod remote;
 pub mod wal;
 pub mod manager;
+pub mod clickhouse;
 
 use crate::{error::*, value::Value};
 use serde::{Deserialize, Serialize};

--- a/src/storage/remote.rs
+++ b/src/storage/remote.rs
@@ -4,8 +4,7 @@ use chrono::{DateTime, Utc};
 use tracing::{info, error, debug};
 use std::path::Path;
 
-mod clickhouse;
-pub use clickhouse::ClickHouseStorage;
+use super::clickhouse::ClickHouseStorage;
 
 #[async_trait::async_trait]
 pub trait RemoteStorage: Send + Sync {


### PR DESCRIPTION
## Summary
- expose `clickhouse` module from `storage`
- update remote storage module to import ClickHouse implementation from sibling module
- import `RemoteStorage`, `S3Storage` and `ClickHouseStorage` in `StorageManager`

## Testing
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_e_685aec8121a0832cac9946b538b62b12