### PR TITLE
Fix compile errors with advanced-storage feature

### DIFF
--- a/src/storage/clickhouse.rs
+++ b/src/storage/clickhouse.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use tracing::{info, warn, error, debug};
 use async_trait::async_trait;
-use super::RemoteStorage;
+use super::remote::RemoteStorage;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct SignalRow {

--- a/src/storage/local.rs
+++ b/src/storage/local.rs
@@ -6,10 +6,10 @@ use parquet::arrow::ArrowWriter;
 use parquet::file::properties::WriterProperties;
 use parquet::basic::Compression;
 use std::fs::{self, File};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 use chrono::{DateTime, Utc};
-use tracing::{info, debug, error};
+use tracing::info;
 
 pub struct LocalStorage {
     config: super::LocalStorageConfig,

--- a/src/storage/manager.rs
+++ b/src/storage/manager.rs
@@ -274,7 +274,11 @@ impl StorageManager {
             
             StorageStrategy::Parallel => {
                 // Write to both in parallel
-                let local_future = self.local.lock().await.write_batch(entries.clone());
+                let local = Arc::clone(&self.local);
+                let entries_clone = entries.clone();
+                let local_future = async move {
+                    local.lock().await.write_batch(entries_clone).await
+                };
                 
                 let remote_future = async {
                     if let Some(remote) = &self.remote {

--- a/src/storage/remote.rs
+++ b/src/storage/remote.rs
@@ -1,10 +1,9 @@
 // src/storage/remote.rs - Complete the existing file
 use crate::{error::*, value::Value};
 use chrono::{DateTime, Utc};
-use tracing::{info, error, debug};
+use tracing::debug;
 use std::path::Path;
 
-use super::clickhouse::ClickHouseStorage;
 
 #[async_trait::async_trait]
 pub trait RemoteStorage: Send + Sync {

--- a/src/storage/wal.rs
+++ b/src/storage/wal.rs
@@ -3,8 +3,8 @@ use rocksdb::{DB, Options, WriteBatch};
 use std::path::Path;
 use std::sync::Arc;
 use parking_lot::Mutex;
-use bytes::{Bytes, BytesMut, BufMut};
-use tracing::{info, error, debug};
+use bytes::{BytesMut, BufMut};
+use tracing::{info, debug};
 
 pub struct WriteAheadLog {
     db: Arc<Mutex<DB>>,


### PR DESCRIPTION
## Summary
- ensure ClickHouse storage imports the correct RemoteStorage trait
- fix lifetime bug in parallel writes for storage manager
- clean up unused imports

## Testing
- `cargo check`
- `cargo test -- --test-threads=1 --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_685af938f72c832c92cbce26481d6916