### PR TITLE
Fix Twilio error handler closures

### DIFF
--- a/src/twilio.rs
+++ b/src/twilio.rs
@@ -315,16 +315,23 @@ impl TwilioConnector {
             .form(&params)
             .send()
             .await
-            .map_err(|e| PlcError::Io(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("HTTP request failed: {}", e)
-            )))?;
+            .map_err(|e| {
+                PlcError::Io(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("HTTP request failed: {}", e),
+                ))
+            })?;
         
         let status = response.status();
-        let body = response.text().await.map_err(|e| PlcError::Io(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("Failed to read response: {}", e)
-        )))?;
+        let body = response
+            .text()
+            .await
+            .map_err(|e| {
+                PlcError::Io(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("Failed to read response: {}", e),
+                ))
+            })?;
         
         if status.is_success() {
             match serde_json::from_str::<MessageResponse>(&body) {
@@ -387,16 +394,23 @@ impl TwilioConnector {
             .form(&params)
             .send()
             .await
-            .map_err(|e| PlcError::Io(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("HTTP request failed: {}", e)
-            )))?;
+            .map_err(|e| {
+                PlcError::Io(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("HTTP request failed: {}", e),
+                ))
+            })?;
         
         let status = response.status();
-        let body = response.text().await.map_err(|e| PlcError::Io(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("Failed to read response: {}", e)
-        )))?;
+        let body = response
+            .text()
+            .await
+            .map_err(|e| {
+                PlcError::Io(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("Failed to read response: {}", e),
+                ))
+            })?;
         
         if status.is_success() {
             match serde_json::from_str::<CallResponse>(&body) {

--- a/src/twilio_block.rs
+++ b/src/twilio_block.rs
@@ -158,10 +158,12 @@ async fn send_sms_async(
         .form(&params)
         .send()
         .await
-        .map_err(|e| PlcError::Io(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("HTTP request failed: {}", e)
-        )))?;
+        .map_err(|e| {
+            PlcError::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("HTTP request failed: {}", e),
+            ))
+        })?;
     
     if response.status().is_success() {
         Ok(())
@@ -202,10 +204,12 @@ async fn make_call_async(
         .form(&params)
         .send()
         .await
-        .map_err(|e| PlcError::Io(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("HTTP request failed: {}", e)
-        )))?;
+        .map_err(|e| {
+            PlcError::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("HTTP request failed: {}", e),
+            ))
+        })?;
     
     if response.status().is_success() {
         Ok(())


### PR DESCRIPTION
## Summary
- adjust `map_err` closures in Twilio modules for clarity
- keep multi-line formatting consistent across Twilio send functions

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685afdd7ca00832c92574b833015299f