### PR TITLE
Fix missing edges import in React designer

### DIFF
--- a/petra-designer/src/App.tsx
+++ b/petra-designer/src/App.tsx
@@ -2,7 +2,6 @@ import { ReactFlow, Background, Controls, MiniMap, Panel } from '@xyflow/react'
 import { Toaster } from 'react-hot-toast'
 import { useFlowStore } from './store/flowStore'
 import { nodeTypes } from './nodes'
-import { edgeTypes } from './edges'
 import Sidebar from './components/Sidebar'
 import PropertiesPanel from './components/PropertiesPanel'
 import YamlPreview from './components/YamlPreview'
@@ -34,7 +33,6 @@ function App() {
             onEdgesChange={onEdgesChange}
             onConnect={onConnect}
             nodeTypes={nodeTypes}
-            edgeTypes={edgeTypes}
             fitView
             className="bg-gray-50"
           >


### PR DESCRIPTION
## Summary
- remove leftover edges import
- drop unused `edgeTypes` prop in `App.tsx`

## Testing
- `cargo test --quiet`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_685b16d31ddc832ca3d37cccdc0058e6