### PR TITLE
Add read/write mode to designer signal node

### DIFF
--- a/petra-designer/src/components/PropertiesPanel.tsx
+++ b/petra-designer/src/components/PropertiesPanel.tsx
@@ -103,6 +103,11 @@ export default function PropertiesPanel() {
         {/* Signal node */}
         {isSignalNode(node) && (
           <>
+            {renderSelect('Mode', 'mode', [
+              { value: 'write', label: 'Write' },
+              { value: 'read', label: 'Read' },
+            ])}
+
             {renderSelect('Signal Type', 'signalType', [
               { value: 'bool', label: 'Boolean' },
               { value: 'int', label: 'Integer' },

--- a/petra-designer/src/nodes/SignalNode.tsx
+++ b/petra-designer/src/nodes/SignalNode.tsx
@@ -24,6 +24,15 @@ function SignalNode({ data, selected }: NodeProps) {
         {signalData.signalType}: {String(signalData.initial)}
       </div>
 
+      {signalData.mode === 'read' && (
+        <Handle
+          type="target"
+          position={Position.Left}
+          className="w-3 h-3"
+          style={{ background: color }}
+        />
+      )}
+
       <Handle
         type="source"
         position={Position.Right}

--- a/petra-designer/src/store/flowStore.ts
+++ b/petra-designer/src/store/flowStore.ts
@@ -189,6 +189,7 @@ function getDefaultNodeData(type: string): any {
         label: 'New Signal',
         signalType: 'float',
         initial: 0,
+        mode: 'write',
       }
     case 'block':
       const blockType = 'AND'

--- a/petra-designer/src/types/nodes.ts
+++ b/petra-designer/src/types/nodes.ts
@@ -10,6 +10,7 @@ export interface BaseNodeData {
 export interface SignalNodeData extends BaseNodeData {
   signalType: 'bool' | 'int' | 'float'
   initial: boolean | number
+  mode: 'read' | 'write'
 }
 
 export interface BlockNodeData extends BaseNodeData {

--- a/petra-designer/src/utils/validation.ts
+++ b/petra-designer/src/utils/validation.ts
@@ -91,6 +91,10 @@ function validateSignalNode(data: SignalNodeData): ValidationResult {
     return { valid: false, error: 'Invalid signal type' }
   }
 
+  if (data.mode && !['read', 'write'].includes(data.mode)) {
+    return { valid: false, error: 'Invalid signal mode' }
+  }
+
   return { valid: true }
 }
 


### PR DESCRIPTION
## Summary
- add `mode` field to `SignalNodeData`
- show an input handle for signal nodes when in read mode
- expose signal `mode` in properties panel
- set default mode to write for new signal nodes
- validate the new signal mode

## Testing
- `cargo test`
- `npm install` *(for petra-designer)*
- `npm run build` *(for petra-designer)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_685d761c6818832cb35830d1b5f4442c