### PR TITLE
Fix AlarmConfig compile error

### DIFF
--- a/src/alarms.rs
+++ b/src/alarms.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use parking_lot::RwLock;
-use chrono::{DateTime, Utc, Local, Timelike};
+use chrono::{DateTime, Utc, Local, Timelike, Datelike};
 use tokio::time::{interval, Duration};
 use tracing::{info, warn, error};
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ use crate::mqtt::MqttConfig;
 use crate::s7::S7Config;
 use crate::twilio::TwilioConfig;
 use crate::history::HistoryConfig;
+use crate::alarms::AlarmConfig;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod value;
 pub mod signal;
 pub mod block;
 pub mod config;
+pub mod alarms;
 pub mod engine;
 pub mod mqtt;
 pub mod twilio;


### PR DESCRIPTION
## Summary
- declare alarms module and use it in config
- rename `alarm_manager.rs` to `alarms.rs`
- import `Datelike` for alarm weekday checks

## Testing
- `cargo check --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685dc070e114832c9a46c71dbd7aae6e