### PR TITLE
Fix Sidebar parse error

### DIFF
--- a/petra-designer/src/components/Sidebar.tsx
+++ b/petra-designer/src/components/Sidebar.tsx
@@ -5,6 +5,9 @@ import {
   FaPhone,
   FaServer,
   FaIndustry,
+  FaBell,
+  FaUser,
+  FaEnvelope,
 } from 'react-icons/fa'
 
 const nodeTypes = [
@@ -64,7 +67,6 @@ const nodeTypes = [
     color: 'text-blue-500',
     description: 'Email alerts',
   },
-]
 ]
 
 export default function Sidebar() {


### PR DESCRIPTION
## Summary
- update icon imports in Sidebar
- remove an extra closing bracket in Sidebar

## Testing
- `npm run build` *(fails: TypeScript error)*
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685dfd65d890832c86febc59f40243df