### PR TITLE
Fix alarm message type

### DIFF
--- a/petra-designer/src/components/PropertiesPanel.tsx
+++ b/petra-designer/src/components/PropertiesPanel.tsx
@@ -195,7 +195,7 @@ export default function PropertiesPanel() {
                 Alarm Message
               </label>
               <textarea
-                value={node.data.message || ''}
+                value={String(node.data.message || '')}
                 onChange={createChangeHandler('message')}
                 rows={3}
                 placeholder="Use {name}, {value}, {setpoint}, {signal} as placeholders"


### PR DESCRIPTION
## Summary
- ensure the alarm message text area always receives a string

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685e06b6fd24832c8d7cc5929cb29074