### PR TITLE
Fix circuit breaker compile errors

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -1,8 +1,10 @@
 use crate::{error::*, signal::SignalBus, value::Value, config::BlockConfig};
-use std::time::Instant;
+use std::time::{Instant, Duration};
 use tracing::trace;
 use crate::twilio_block::TwilioBlock;
 use std::f64::consts::PI;
+use std::sync::atomic::{AtomicU32, AtomicBool, Ordering};
+use parking_lot::RwLock;
 
 pub struct Counter {
     name: String,

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,10 @@ pub enum PlcError {
     /// Returned value type does not match the expected type
     #[error("Type mismatch: expected {expected}, got {actual}")]
     TypeMismatch { expected: &'static str, actual: &'static str },
+
+    /// Circuit breaker is open for a block
+    #[error("Circuit breaker open")]
+    CircuitOpen,
 }
 
 /// Convenient alias over [`Result`] using [`PlcError`]


### PR DESCRIPTION
## Summary
- import missing atomic and duration types in `block.rs`
- add `CircuitOpen` variant to `PlcError`

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685e165a0d5c832ca7839061709446a4