### PR TITLE
Fix MQTT TLS build without security feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ jsonschema = { version = "0.18", optional = true }
 ring = "0.17"
 webpki = { version = "0.22", optional = true }
 rustls = { version = "0.23", optional = true }
+rustls-pemfile = { version = "2", optional = true }
 audit = { version = "0.1", optional = true }
 
 # OPC-UA support
@@ -171,5 +172,5 @@ advanced-storage = ["rocksdb", "clickhouse", "object_store", "aws-sdk-s3", "aws-
 json-schema = ["schemars", "jsonschema"]
 opcua-support = ["opcua"]
 modbus-support = ["tokio-modbus"]
-security = ["audit", "rustls", "webpki"]
+security = ["audit", "rustls", "webpki", "rustls-pemfile"]
 enhanced = []

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -5,7 +5,9 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::{info, warn, debug, error};
 use std::collections::HashMap;
+#[cfg(feature = "security")]
 use rustls::{ClientConfig, RootCertStore, Certificate, PrivateKey};
+#[cfg(feature = "security")]
 use std::sync::Arc;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -142,6 +144,7 @@ impl MqttHandler {
         })
     }
 
+    #[cfg(feature = "security")]
     fn build_tls_config(config: &MqttConfig) -> Result<Transport> {
         use std::io::BufReader;
         use std::fs;
@@ -204,6 +207,11 @@ impl MqttHandler {
 
         let tls_config = TlsConfiguration::Rustls(Arc::new(client_config));
         Ok(Transport::tls_with_config(tls_config))
+    }
+
+    #[cfg(not(feature = "security"))]
+    fn build_tls_config(_config: &MqttConfig) -> Result<Transport> {
+        Err(PlcError::Config("TLS support not enabled".to_string()))
     }
 
     /// Provide a channel receiving signal change notifications


### PR DESCRIPTION
## Summary
- add optional `rustls-pemfile` dependency
- include `rustls-pemfile` in the `security` feature
- gate TLS imports and helper under `security` feature

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_685f12f0d9a4832c81cd4651b3036eac