### PR TITLE
Enable connect feature for async-stripe

### DIFF
--- a/ca-service/Cargo.toml
+++ b/ca-service/Cargo.toml
@@ -19,7 +19,7 @@ x509-parser = "0.16"
 sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "uuid", "chrono", "json"],default-features = false }
 
 # Payments
-async-stripe = {  version = "0.41",  features = ["runtime-tokio-hyper", "billing", "checkout", "webhook-events"], default-features = false }
+async-stripe = {  version = "0.41",  features = ["runtime-tokio-hyper", "billing", "checkout", "webhook-events", "connect"], default-features = false }
 
 # Email - Fixed with proper TLS features
 lettre = { version = "0.11",  features = [ "tokio1-rustls" , "builder", "smtp-transport", "ring", "rustls-native-certs" ], default-features = false }


### PR DESCRIPTION
## Summary
- enable the `connect` feature of `async-stripe` in `petra-ca-service`

The Stripe webhook handler requires the `AccountCapabilities` type which is only
available with the `connect` feature enabled. Without this feature the crate
fails to compile with `cannot find type 'AccountCapabilities'` errors.

## Testing
- `cargo check --all --all-targets` *(fails: could not compile `petra-ca-service`)*

------
https://chatgpt.com/codex/tasks/task_e_68615daf584c832cba10ca06b04ee093