### PR TITLE
Fix default build errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Programmable Engine for Telemetry, Runtime, and Automation"
 
 [dependencies]
 # Core runtime - minimal features only
-tokio = { version = "1.40", features = ["rt-multi-thread", "time", "signal", "macros"] }
+tokio = { version = "1.40", features = ["rt-multi-thread", "time", "signal", "macros", "sync"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"
@@ -29,7 +29,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"], default-featu
 rumqttc = { version = "0.24", default-features = false, features = ["use-rustls"] }
 
 # CLI
-clap = { version = "4.5", features = ["std"] }
+clap = { version = "4.5", features = ["std", "derive"] }
 
 # Time handling
 chrono = { version = "0.4.38", features = ["serde"], default-features = false }
@@ -40,6 +40,7 @@ ringbuffer = "0.15"
 async-trait = "0.1"
 regex = "1.10"
 base64 = "0.22"
+htmlescape = "0.3"
 
 # S7 communication (only if needed)
 rust-snap7 = { version = "1.142.2", optional = true }
@@ -48,7 +49,7 @@ rust-snap7 = { version = "1.142.2", optional = true }
 reqwest = { version = "0.11", features = ["json", "rustls-tls"], default-features = false, optional = true }
 
 # Metrics - lightweight
-metrics = { version = "0.23", default-features = false, optional = true }
+metrics = { version = "0.23", default-features = false }
 metrics-exporter-prometheus = { version = "0.15", default-features = false, optional = true }
 
 # Storage - all optional for production flexibility
@@ -97,7 +98,7 @@ mqtt = []
 
 # Optional heavy features
 advanced-storage = ["rocksdb", "clickhouse", "object_store", "aws-sdk-s3", "aws-config", "zstd", "lz4"]
-metrics = ["dep:metrics", "metrics-exporter-prometheus"]
+metrics = ["metrics-exporter-prometheus"]
 web = ["reqwest"]
 security = ["ring", "rustls", "rustls-pemfile"]
 opcua-support = ["opcua"]

--- a/src/alarms.rs
+++ b/src/alarms.rs
@@ -494,6 +494,7 @@ impl EmailSender for SmtpEmailSender {
 }
 
 // SMS implementation using Twilio (reuse existing)
+#[cfg(feature = "web")]
 pub struct TwilioSmsSender {
    client: reqwest::Client,
    account_sid: String,
@@ -501,6 +502,7 @@ pub struct TwilioSmsSender {
    from_number: String,
 }
 
+#[cfg(feature = "web")]
 #[async_trait::async_trait]
 impl SmsSender for TwilioSmsSender {
    async fn send_sms(&self, to: &str, message: &str) -> Result<()> {

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,6 +1,7 @@
 use crate::{error::*, signal::SignalBus, value::Value, config::BlockConfig};
 use std::time::{Instant, Duration};
 use tracing::trace;
+#[cfg(feature = "web")]
 use crate::twilio_block::TwilioBlock;
 use std::f64::consts::PI;
 use std::sync::atomic::{AtomicU32, AtomicBool, Ordering};
@@ -439,6 +440,7 @@ pub fn create_block(config: &BlockConfig) -> Result<Box<dyn Block>> {
             }))
         }
         // Add to the create_block function
+        #[cfg(feature = "web")]
         "TWILIO" => {
             let trigger = config.inputs.get("trigger")
                 .ok_or_else(|| PlcError::Config("TWILIO block requires 'trigger' input".into()))?;
@@ -465,7 +467,7 @@ pub fn create_block(config: &BlockConfig) -> Result<Box<dyn Block>> {
             let cooldown_ms = config.params.get("cooldown_ms")
                 .and_then(|v| v.as_u64())
                 .unwrap_or(300000); // 5 minutes default
-            
+
             Ok(Box::new(TwilioBlock::new(
                 config.name.clone(),
                 trigger.clone(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,9 @@
 use crate::error::*;
 use crate::mqtt::MqttConfig;
 use crate::s7::S7Config;
+#[cfg(feature = "web")]
 use crate::twilio::TwilioConfig;
+#[cfg(feature = "history")]
 use crate::history::HistoryConfig;
 use crate::alarms::AlarmConfig;
 #[cfg(feature = "opcua-support")]
@@ -27,8 +29,10 @@ pub struct Config {
     pub mqtt: MqttConfig,
     #[serde(default)]
     pub s7: Option<S7Config>,
+    #[cfg(feature = "web")]
     #[serde(default)]
     pub twilio: Option<TwilioConfig>,
+    #[cfg(feature = "history")]
     #[serde(default)]
     pub history: Option<HistoryConfig>,
     #[cfg(feature = "advanced-storage")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod value;
 pub mod signal;
 pub mod block;
 pub mod config;
+#[cfg(feature = "security")]
 pub mod config_secure;
 pub mod alarms;
 pub mod engine;
@@ -21,7 +22,9 @@ pub mod realtime;
 #[cfg(feature = "enhanced")]
 pub mod validation;
 pub mod mqtt;
+#[cfg(feature = "web")]
 pub mod twilio;
+#[cfg(feature = "web")]
 pub mod twilio_block;
 #[cfg(feature = "opcua-support")]
 pub mod opcua;
@@ -60,6 +63,7 @@ pub use health::StorageHealthCheck;
 pub use realtime::{RealtimeConfig, configure_realtime};
 #[cfg(feature = "enhanced")]
 pub use validation::{ValidationRules, ValueRange};
+#[cfg(feature = "security")]
 pub use config_secure::{ConfigSigner, ConfigVerifier, SecureConfig};
 pub use config::Config;
 pub use engine::{Engine, EngineStats};
@@ -71,6 +75,7 @@ pub use history::{HistoryManager, HistoryConfig, SignalHistory};
 #[cfg(feature = "s7-support")]
 pub use s7::{S7Connector, S7Config, S7Mapping, S7Area, S7DataType, Direction};
 
+#[cfg(feature = "web")]
 pub use twilio::{TwilioConnector, TwilioConfig, TwilioAction, TwilioActionType};
 
 #[cfg(feature = "opcua-support")]

--- a/src/twilio.rs
+++ b/src/twilio.rs
@@ -247,8 +247,8 @@ impl TwilioConnector {
             
             let was_truthy = state.last_value.as_ref()
                 .map(|last| match last {
-                    Value::Bool(b) => *b,
-                    Value::Int(i) => *i != 0,
+                    Value::Bool(b) => b,
+                    Value::Int(i) => i != 0,
                     Value::Float(f) => f.abs() > f64::EPSILON,
                 })
                 .unwrap_or(false);


### PR DESCRIPTION
## Summary
- enable tokio sync and clap derive features
- include htmlescape
- make metrics non-optional
- guard optional modules behind feature flags
- fix bool handling in Twilio connector

## Testing
- `cargo check --lib`

------
https://chatgpt.com/codex/tasks/task_e_686160c5edd8832c8b40dbc4e773cd0e