### PR TITLE
Fix benchmarks to compile with current API

### DIFF
--- a/benches/engine_performance.rs
+++ b/benches/engine_performance.rs
@@ -1,66 +1,64 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use petra::config::{BlockConfig, SignalConfig};
 use petra::{Config, Engine, SignalBus, Value};
-use petra::config::{SignalConfig, BlockConfig, SignalType, InitialValue};
-use petra::block::{Block, BlockFactory};
 use std::collections::HashMap;
 use std::time::Duration;
 
 fn create_benchmark_config(num_signals: usize, num_blocks: usize) -> Config {
     let mut signals = Vec::new();
     let mut blocks = Vec::new();
-    
+
     // Create signals
     for i in 0..num_signals {
         signals.push(SignalConfig {
             name: format!("signal_{}", i),
             signal_type: "float".to_string(),
-            initial: Some(InitialValue::Float(0.0)),
-            description: None,
-            unit: None,
-            min: None,
-            max: None,
-            s7_config: None,
-            modbus_config: None,
-            persistence: None,
-            history: None,
-            validation: None,
-            max_updates_per_second: None,
+            initial: serde_yaml::Value::from(0.0f64),
         });
     }
-    
+
     // Create simple logic blocks (AND gates with 2 inputs)
     for i in 0..num_blocks {
         let mut inputs = HashMap::new();
-        inputs.insert("in1".to_string(), petra::config::BlockInput::Signal(format!("signal_{}", i % num_signals)));
-        inputs.insert("in2".to_string(), petra::config::BlockInput::Signal(format!("signal_{}", (i + 1) % num_signals)));
-        
+        inputs.insert("in1".to_string(), format!("signal_{}", i % num_signals));
+        inputs.insert(
+            "in2".to_string(),
+            format!("signal_{}", (i + 1) % num_signals),
+        );
+
         let mut outputs = HashMap::new();
-        outputs.insert("out".to_string(), format!("signal_{}", (i + num_signals) % num_signals));
-        
+        outputs.insert(
+            "out".to_string(),
+            format!("signal_{}", (i + num_signals) % num_signals),
+        );
+
         blocks.push(BlockConfig {
             name: format!("block_{}", i),
             block_type: "AND".to_string(),
             inputs,
             outputs,
-            params: None,
+            params: HashMap::new(),
         });
     }
-    
+
     Config {
         signals,
         blocks,
         scan_time_ms: 50,
-        mqtt: None,
-        twilio: None,
-        s7_connections: None,
-        modbus_connections: None,
+        mqtt: Default::default(),
+        s7: None,
         alarms: None,
-        history: None,
-        storage: None,
         security: None,
+        #[cfg(feature = "web")]
+        twilio: None,
+        #[cfg(feature = "history")]
+        history: None,
+        #[cfg(feature = "advanced-storage")]
+        storage: None,
+        #[cfg(feature = "opcua-support")]
         opcua: None,
-        max_signals: None,
-        signal_ttl_secs: None,
+        #[cfg(feature = "modbus-support")]
+        modbus: None,
     }
 }
 
@@ -68,15 +66,18 @@ fn benchmark_scan_performance(c: &mut Criterion) {
     let mut group = c.benchmark_group("scan_performance");
     group.measurement_time(Duration::from_secs(10));
     group.warm_up_time(Duration::from_secs(3));
-    
+
     // Test different scales
     for (num_signals, num_blocks) in &[(100, 10), (1000, 100), (10000, 1000)] {
         let config = create_benchmark_config(*num_signals, *num_blocks);
         let mut engine = Engine::new(config).expect("Failed to create engine");
-        
+
         group.throughput(Throughput::Elements(*num_blocks as u64));
         group.bench_with_input(
-            BenchmarkId::new("signals_and_blocks", format!("{}/{}", num_signals, num_blocks)),
+            BenchmarkId::new(
+                "signals_and_blocks",
+                format!("{}/{}", num_signals, num_blocks),
+            ),
             &(num_signals, num_blocks),
             |b, _| {
                 b.iter(|| {
@@ -85,191 +86,177 @@ fn benchmark_scan_performance(c: &mut Criterion) {
             },
         );
     }
-    
+
     group.finish();
 }
 
 fn benchmark_signal_bus_operations(c: &mut Criterion) {
     let mut group = c.benchmark_group("signal_bus");
     group.measurement_time(Duration::from_secs(5));
-    
+
     let bus = SignalBus::new();
-    
+
     // Pre-populate signals
     for i in 0..1000 {
-        bus.write_signal(&format!("signal_{}", i), Value::Float(0.0))
-            .expect("Failed to write signal");
+        bus.set(&format!("signal_{}", i), Value::Float(0.0))
+            .unwrap();
     }
-    
+
     group.bench_function("write_single", |b| {
         let mut counter = 0;
         b.iter(|| {
-            let _ = bus.write_signal(
-                &format!("signal_{}", counter % 1000), 
-                Value::Float(black_box(counter as f64))
+            let _ = bus.set(
+                &format!("signal_{}", counter % 1000),
+                Value::Float(black_box(counter as f64)),
             );
             counter += 1;
         });
     });
-    
+
     group.bench_function("read_single", |b| {
         let mut counter = 0;
         b.iter(|| {
-            let _ = bus.read_signal(&format!("signal_{}", counter % 1000));
+            let _ = bus.get(&format!("signal_{}", counter % 1000));
             counter += 1;
         });
     });
-    
+
     group.bench_function("batch_write_10", |b| {
         b.iter(|| {
-            let updates: Vec<(&str, Value)> = (0..10)
-                .map(|i| {
-                    let signal = format!("signal_{}", i);
-                    // Leak the string to get a &'static str for the benchmark
-                    let leaked = Box::leak(signal.into_boxed_str());
-                    (leaked as &str, Value::Float(i as f64))
-                })
+            let updates: Vec<(String, Value)> = (0..10)
+                .map(|i| (format!("signal_{}", i), Value::Float(i as f64)))
                 .collect();
-            let _ = bus.write_batch(updates);
+            for (name, value) in &updates {
+                let _ = bus.set(name, value.clone());
+            }
         });
     });
-    
+
     group.bench_function("concurrent_read_write", |b| {
         use std::sync::Arc;
         use std::thread;
-        
+
         let bus = Arc::new(SignalBus::new());
-        
+
         // Pre-populate
         for i in 0..100 {
-            bus.write_signal(&format!("sig_{}", i), Value::Float(0.0))
-                .expect("Failed to write");
+            bus.set(&format!("sig_{}", i), Value::Float(0.0)).unwrap();
         }
-        
+
         b.iter(|| {
             let mut handles = vec![];
-            
+
             // Spawn readers
             for i in 0..4 {
                 let bus_clone = bus.clone();
                 let handle = thread::spawn(move || {
                     for j in 0..25 {
-                        let _ = bus_clone.read_signal(&format!("sig_{}", (i * 25 + j) % 100));
+                        let _ = bus_clone.get(&format!("sig_{}", (i * 25 + j) % 100));
                     }
                 });
                 handles.push(handle);
             }
-            
+
             // Spawn writers
             for i in 0..2 {
                 let bus_clone = bus.clone();
                 let handle = thread::spawn(move || {
                     for j in 0..50 {
-                        let _ = bus_clone.write_signal(
+                        let _ = bus_clone.set(
                             &format!("sig_{}", (i * 50 + j) % 100),
-                            Value::Float(j as f64)
+                            Value::Float(j as f64),
                         );
                     }
                 });
                 handles.push(handle);
             }
-            
+
             // Wait for all threads
             for handle in handles {
                 handle.join().unwrap();
             }
         });
     });
-    
+
     group.finish();
 }
 
 fn benchmark_block_execution(c: &mut Criterion) {
     use petra::block::*;
-    
+
     let mut group = c.benchmark_group("block_execution");
     let bus = SignalBus::new();
-    
+
     // Initialize signals
-    bus.write_signal("input1", Value::Bool(true)).unwrap();
-    bus.write_signal("input2", Value::Bool(false)).unwrap();
-    bus.write_signal("output", Value::Bool(false)).unwrap();
-    bus.write_signal("float_in", Value::Float(50.0)).unwrap();
-    bus.write_signal("float_out", Value::Float(0.0)).unwrap();
-    
-    // Create blocks using the factory
-    let factory = BlockFactory::new();
-    
+    bus.set("input1", Value::Bool(true)).unwrap();
+    bus.set("input2", Value::Bool(false)).unwrap();
+    bus.set("output", Value::Bool(false)).unwrap();
+    bus.set("float_in", Value::Float(50.0)).unwrap();
+    bus.set("float_out", Value::Float(0.0)).unwrap();
+
+    // Create blocks directly using the helper
+
     // AND block
-    let mut and_config = BlockConfig {
+    let and_config = BlockConfig {
         name: "test_and".to_string(),
         block_type: "AND".to_string(),
         inputs: HashMap::from([
-            ("in1".to_string(), petra::config::BlockInput::Signal("input1".to_string())),
-            ("in2".to_string(), petra::config::BlockInput::Signal("input2".to_string())),
+            ("in1".to_string(), "input1".to_string()),
+            ("in2".to_string(), "input2".to_string()),
         ]),
-        outputs: HashMap::from([
-            ("out".to_string(), "output".to_string()),
-        ]),
-        params: None,
+        outputs: HashMap::from([("out".to_string(), "output".to_string())]),
+        params: HashMap::new(),
     };
-    
-    let mut and_block = factory.create_block(&and_config)
-        .expect("Failed to create AND block");
-    
+
+    let mut and_block = create_block(&and_config).expect("Failed to create AND block");
+
     group.bench_function("and_block", |b| {
         b.iter(|| {
             and_block.execute(&bus).unwrap();
         });
     });
-    
+
     // Math block (more complex)
-    let mut math_config = BlockConfig {
+    let math_config = BlockConfig {
         name: "test_math".to_string(),
         block_type: "Math".to_string(),
         inputs: HashMap::from([
-            ("a".to_string(), petra::config::BlockInput::Signal("float_in".to_string())),
-            ("b".to_string(), petra::config::BlockInput::Value(
-                petra::config::ValueOrSignal::Value(Value::Float(2.0))
-            )),
+            ("a".to_string(), "float_in".to_string()),
+            ("b".to_string(), "2.0".to_string()),
         ]),
-        outputs: HashMap::from([
-            ("result".to_string(), "float_out".to_string()),
-        ]),
-        params: Some(HashMap::from([
-            ("operation".to_string(), serde_json::json!("multiply")),
-        ])),
+        outputs: HashMap::from([("result".to_string(), "float_out".to_string())]),
+        params: HashMap::from([("operation".to_string(), serde_yaml::Value::from("multiply"))]),
     };
-    
-    let mut math_block = factory.create_block(&math_config)
-        .expect("Failed to create Math block");
-    
+
+    let mut math_block = create_block(&math_config).expect("Failed to create Math block");
+
     group.bench_function("math_block", |b| {
         b.iter(|| {
             math_block.execute(&bus).unwrap();
         });
     });
-    
+
     group.finish();
 }
 
+#[cfg(feature = "history")]
 fn benchmark_history_write(c: &mut Criterion) {
-    use petra::history::{HistoryManager, HistoryConfig};
+    use petra::history::{HistoryConfig, HistoryManager};
     use std::sync::Arc;
     use tokio::runtime::Runtime;
-    
+
     let mut group = c.benchmark_group("history");
     group.measurement_time(Duration::from_secs(5));
-    
+
     let rt = Runtime::new().unwrap();
     let bus = Arc::new(SignalBus::new());
-    
+
     // Pre-populate signals
     for i in 0..100 {
-        bus.write_signal(&format!("hist_signal_{}", i), Value::Float(i as f64))
+        bus.set(&format!("hist_signal_{}", i), Value::Float(i as f64))
             .unwrap();
     }
-    
+
     let config = HistoryConfig {
         enabled: true,
         directory: "/tmp/petra_bench_history".into(),
@@ -278,14 +265,14 @@ fn benchmark_history_write(c: &mut Criterion) {
         retention_days: 7,
         signals: Some(vec!["hist_signal_*".to_string()]),
     };
-    
+
     group.bench_function("history_batch_write", |b| {
         let manager = rt.block_on(async {
             HistoryManager::new(config.clone(), bus.clone())
                 .await
                 .expect("Failed to create history manager")
         });
-        
+
         b.iter(|| {
             rt.block_on(async {
                 // Simulate a batch of signal changes
@@ -297,9 +284,9 @@ fn benchmark_history_write(c: &mut Criterion) {
             });
         });
     });
-    
+
     group.finish();
-    
+
     // Cleanup
     let _ = std::fs::remove_dir_all("/tmp/petra_bench_history");
 }
@@ -308,65 +295,73 @@ fn benchmark_history_write(c: &mut Criterion) {
 fn benchmark_enhanced_features(c: &mut Criterion) {
     use petra::{EnhancedSignalBus, SignalBusConfig};
     use std::time::Duration;
-    
+
     let mut group = c.benchmark_group("enhanced_features");
-    
+
     let config = SignalBusConfig {
         max_signals: 10000,
         signal_ttl: Duration::from_secs(3600),
         cleanup_interval: Duration::from_secs(60),
         hot_signal_threshold: 100,
     };
-    
+
     let bus = EnhancedSignalBus::new(config);
-    
+
     // Pre-populate
     for i in 0..1000 {
-        bus.write_signal(&format!("signal_{}", i), Value::Float(0.0)).unwrap();
+        bus.set(&format!("signal_{}", i), Value::Float(0.0))
+            .unwrap();
     }
-    
+
     // Make a signal "hot"
     for _ in 0..200 {
-        let _ = bus.read_signal("hot_signal");
+        let _ = bus.get("hot_signal");
     }
-    
+
     group.bench_function("enhanced_write_hot_signal", |b| {
         b.iter(|| {
-            bus.write_signal("hot_signal", Value::Float(black_box(42.0))).unwrap();
+            bus.set("hot_signal", Value::Float(black_box(42.0)))
+                .unwrap();
         });
     });
-    
+
     group.bench_function("enhanced_read_hot_signal", |b| {
         b.iter(|| {
-            let _ = bus.read_signal("hot_signal").unwrap();
+            let _ = bus.get("hot_signal").unwrap();
         });
     });
-    
+
     group.bench_function("enhanced_cold_signal", |b| {
         let mut counter = 0;
         b.iter(|| {
             let signal = format!("cold_signal_{}", counter % 100);
-            let _ = bus.read_signal(&signal);
+            let _ = bus.get(&signal);
             counter += 1;
         });
     });
-    
+
     group.finish();
 }
 
+#[cfg(feature = "history")]
 criterion_group!(
-    benches, 
+    benches,
     benchmark_scan_performance,
     benchmark_signal_bus_operations,
     benchmark_block_execution,
     benchmark_history_write,
 );
 
-#[cfg(feature = "enhanced")]
+#[cfg(not(feature = "history"))]
 criterion_group!(
-    enhanced_benches,
-    benchmark_enhanced_features
+    benches,
+    benchmark_scan_performance,
+    benchmark_signal_bus_operations,
+    benchmark_block_execution,
 );
+
+#[cfg(feature = "enhanced")]
+criterion_group!(enhanced_benches, benchmark_enhanced_features);
 
 #[cfg(not(feature = "enhanced"))]
 criterion_main!(benches);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -290,6 +290,17 @@ impl Engine {
         Ok(())
     }
 
+    /// Execute a single scan cycle synchronously. Primarily for benchmarks.
+    pub fn execute_scan_cycle(&mut self) {
+        for block in &mut self.blocks {
+            if let Err(e) = block.execute(&self.bus) {
+                self.error_count.fetch_add(1, Ordering::Relaxed);
+                warn!("Block '{}' error: {}", block.name(), e);
+            }
+        }
+        self.scan_count.fetch_add(1, Ordering::Relaxed);
+    }
+
     pub fn stop(&self) {
         info!("Stopping engine...");
         self.running.store(false, Ordering::Relaxed);


### PR DESCRIPTION
## Summary
- update benchmark code for current config and signal APIs
- add `Engine::execute_scan_cycle` helper for Criterion benchmarks

## Testing
- `cargo test --lib`
- `cargo test --test integration test_simple_control_loop`
- `cargo bench --bench engine_performance`

------
https://chatgpt.com/codex/tasks/task_e_686211e28230832c875e19a755f5ceb8