### PR TITLE
Fix WAL append handling and add NotFound error variant

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,9 @@ pub enum PlcError {
     
     #[error("Signal not found: {0}")]
     SignalNotFound(String),
+
+    #[error("Not found: {0}")]
+    NotFound(String),
     
     #[error("Type mismatch: {0}")]
     TypeMismatch(String),


### PR DESCRIPTION
## Summary
- remove erroneous await in WAL append call
- parse WAL values from bytes and include timestamp
- provide NotFound error variant and use it when secondary storage is missing
- add helper to parse `Value` from raw bytes

## Testing
- `cargo check`
- `cargo test --no-run`


------
https://chatgpt.com/codex/tasks/task_e_68636c360a2c832ca18324c629d895b9