### PR TITLE
Fix get_statistics compile issue

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -147,7 +147,7 @@ pub struct HistoryManager {
 }
 
 #[cfg(feature = "history-statistics")]
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct HistoryStatistics {
     total_entries: u64,
     entries_per_signal: std::collections::HashMap<String, u64>,


### PR DESCRIPTION
## Summary
- ensure `HistoryStatistics` implements `Clone`

## Testing
- `cargo check --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68636c11bfc0832cb19d770ed8f5eb3f