### PR TITLE
Refactor alarm processing

### DIFF
--- a/src/alarms.rs
+++ b/src/alarms.rs
@@ -1,11 +1,15 @@
 // src/alarms.rs
-use crate::{error::{Result, PlcError}, signal::SignalBus, value::Value};
+use crate::{
+    error::{PlcError, Result},
+    signal::SignalBus,
+    value::Value,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
-use serde::{Deserialize, Serialize};
-use tracing::{info, warn, error};
 use tokio::sync::mpsc;
-use chrono::{DateTime, Utc};
+use tracing::{error, info, warn};
 
 #[cfg(feature = "alarm-persistence")]
 use std::path::PathBuf;
@@ -17,66 +21,91 @@ pub struct AlarmConfig {
     pub condition: AlarmCondition,
     pub severity: AlarmSeverity,
     pub signal: String,
-    
+
     #[serde(default)]
     pub enabled: bool,
-    
+
     #[cfg(feature = "alarm-actions")]
     #[serde(default)]
     pub actions: Vec<AlarmAction>,
-    
+
     #[cfg(feature = "alarm-groups")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub group: Option<String>,
-    
+
     #[cfg(feature = "alarm-shelving")]
     #[serde(default)]
     pub can_shelve: bool,
-    
+
     #[cfg(feature = "alarm-shelving")]
     #[serde(default)]
     pub shelve_duration_minutes: Option<u32>,
-    
+
     #[cfg(feature = "alarm-history")]
     #[serde(default = "default_true")]
     pub track_history: bool,
-    
+
     #[cfg(feature = "alarm-delay")]
     #[serde(default)]
     pub on_delay_ms: Option<u32>,
-    
+
     #[cfg(feature = "alarm-delay")]
     #[serde(default)]
     pub off_delay_ms: Option<u32>,
-    
+
     #[cfg(feature = "alarm-hysteresis")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hysteresis: Option<f64>,
 }
 
-fn default_true() -> bool { true }
+fn default_true() -> bool {
+    true
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum AlarmCondition {
-    High { threshold: f64 },
-    Low { threshold: f64 },
-    Equal { value: Value },
-    NotEqual { value: Value },
-    InRange { min: f64, max: f64 },
-    OutOfRange { min: f64, max: f64 },
-    
+    High {
+        threshold: f64,
+    },
+    Low {
+        threshold: f64,
+    },
+    Equal {
+        value: Value,
+    },
+    NotEqual {
+        value: Value,
+    },
+    InRange {
+        min: f64,
+        max: f64,
+    },
+    OutOfRange {
+        min: f64,
+        max: f64,
+    },
+
     #[cfg(feature = "extended-alarms")]
-    RateOfChange { max_change_per_second: f64 },
-    
+    RateOfChange {
+        max_change_per_second: f64,
+    },
+
     #[cfg(feature = "extended-alarms")]
-    Deviation { reference_signal: String, max_deviation: f64 },
-    
+    Deviation {
+        reference_signal: String,
+        max_deviation: f64,
+    },
+
     #[cfg(feature = "extended-alarms")]
-    Expression { expression: String },
-    
+    Expression {
+        expression: String,
+    },
+
     #[cfg(feature = "extended-alarms")]
-    Stale { timeout_seconds: u32 },
+    Stale {
+        timeout_seconds: u32,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
@@ -94,21 +123,21 @@ pub enum AlarmSeverity {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum AlarmAction {
-    Email { 
+    Email {
         recipients: Vec<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         template: Option<String>,
     },
-    Sms { 
+    Sms {
         recipients: Vec<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         template: Option<String>,
     },
-    Signal { 
-        name: String, 
-        value: Value 
+    Signal {
+        name: String,
+        value: Value,
     },
-    Command { 
+    Command {
         command: String,
         #[serde(default)]
         args: Vec<String>,
@@ -127,28 +156,28 @@ pub struct Alarm {
     config: AlarmConfig,
     state: AlarmState,
     last_transition: DateTime<Utc>,
-    
+
     #[cfg(feature = "alarm-acknowledgment")]
     acknowledged: bool,
-    
+
     #[cfg(feature = "alarm-acknowledgment")]
     acknowledged_by: Option<String>,
-    
+
     #[cfg(feature = "alarm-acknowledgment")]
     acknowledged_at: Option<DateTime<Utc>>,
-    
+
     #[cfg(feature = "alarm-shelving")]
     shelved_until: Option<DateTime<Utc>>,
-    
+
     #[cfg(feature = "alarm-history")]
     activation_count: u64,
-    
+
     #[cfg(feature = "alarm-delay")]
     delay_start: Option<DateTime<Utc>>,
-    
+
     #[cfg(feature = "extended-alarms")]
     last_value: Option<Value>,
-    
+
     #[cfg(feature = "extended-alarms")]
     last_update: DateTime<Utc>,
 }
@@ -168,36 +197,49 @@ pub struct AlarmManager {
     bus: SignalBus,
     tx: mpsc::Sender<AlarmEvent>,
     rx: mpsc::Receiver<AlarmEvent>,
-    
+
     #[cfg(feature = "alarm-history")]
     history: AlarmHistory,
-    
+
     #[cfg(feature = "alarm-statistics")]
     statistics: AlarmStatistics,
-    
+
     #[cfg(feature = "alarm-groups")]
     groups: HashMap<String, AlarmGroup>,
-    
+
     #[cfg(feature = "alarm-persistence")]
     persistence_path: Option<PathBuf>,
-    
+
     #[cfg(feature = "alarm-actions")]
     action_executor: ActionExecutor,
 }
 
 #[derive(Debug, Clone)]
 pub enum AlarmEvent {
-    Activated { name: String, severity: AlarmSeverity },
-    Deactivated { name: String },
-    
+    Activated {
+        name: String,
+        severity: AlarmSeverity,
+    },
+    Deactivated {
+        name: String,
+    },
+
     #[cfg(feature = "alarm-acknowledgment")]
-    Acknowledged { name: String, by: String },
-    
+    Acknowledged {
+        name: String,
+        by: String,
+    },
+
     #[cfg(feature = "alarm-shelving")]
-    Shelved { name: String, until: DateTime<Utc> },
-    
+    Shelved {
+        name: String,
+        until: DateTime<Utc>,
+    },
+
     #[cfg(feature = "alarm-shelving")]
-    Unshelved { name: String },
+    Unshelved {
+        name: String,
+    },
 }
 
 #[cfg(feature = "alarm-history")]
@@ -238,8 +280,9 @@ struct AlarmGroup {
 impl AlarmManager {
     pub fn new(configs: Vec<AlarmConfig>, bus: SignalBus) -> Result<Self> {
         let (tx, rx) = mpsc::channel(100);
-        
-        let alarms = configs.into_iter()
+
+        let alarms = configs
+            .into_iter()
             .map(|config| Alarm {
                 state: AlarmState::Normal,
                 last_transition: Utc::now(),
@@ -262,7 +305,7 @@ impl AlarmManager {
                 config,
             })
             .collect();
-        
+
         Ok(Self {
             alarms,
             bus,
@@ -283,15 +326,15 @@ impl AlarmManager {
             action_executor: ActionExecutor::new(),
         })
     }
-    
+
     pub async fn run(mut self) -> Result<()> {
         info!("Starting alarm manager with {} alarms", self.alarms.len());
-        
+
         #[cfg(feature = "alarm-persistence")]
         self.load_state()?;
-        
+
         let mut interval = tokio::time::interval(tokio::time::Duration::from_millis(100));
-        
+
         loop {
             tokio::select! {
                 _ = interval.tick() => {
@@ -303,50 +346,56 @@ impl AlarmManager {
             }
         }
     }
-    
+
     async fn check_alarms(&mut self) -> Result<()> {
-        for alarm in &mut self.alarms {
+        let mut to_activate = Vec::new();
+        let mut to_deactivate = Vec::new();
+
+        #[cfg(feature = "alarm-shelving")]
+        let mut to_unshelve = Vec::new();
+
+        for (idx, alarm) in self.alarms.iter_mut().enumerate() {
             if !alarm.config.enabled {
                 continue;
             }
-            
+
             #[cfg(feature = "alarm-shelving")]
             if let Some(until) = alarm.shelved_until {
                 if Utc::now() > until {
-                    alarm.shelved_until = None;
-                    alarm.state = AlarmState::Normal;
-                    let _ = self.tx.send(AlarmEvent::Unshelved {
-                        name: alarm.config.name.clone()
-                    }).await;
+                    to_unshelve.push(idx);
                 } else {
                     continue; // Skip shelved alarms
                 }
             }
-            
+
             let signal_value = match self.bus.get(&alarm.config.signal) {
                 Some(value) => value,
                 None => {
-                    warn!("Signal '{}' not found for alarm '{}'", 
-                          alarm.config.signal, alarm.config.name);
+                    warn!(
+                        "Signal '{}' not found for alarm '{}'",
+                        alarm.config.signal, alarm.config.name
+                    );
                     continue;
                 }
             };
-            
+
             #[cfg(feature = "extended-alarms")]
             {
                 alarm.last_value = Some(signal_value.clone());
                 alarm.last_update = Utc::now();
             }
-            
-            let should_activate = self.evaluate_condition(&alarm.config.condition, &signal_value)?;
-            
+
+            let mut should_activate =
+                self.evaluate_condition(&alarm.config.condition, &signal_value)?;
+
             #[cfg(feature = "alarm-hysteresis")]
-            let should_activate = if let Some(hysteresis) = alarm.config.hysteresis {
-                self.apply_hysteresis(alarm, should_activate, &signal_value, hysteresis)
-            } else {
-                should_activate
-            };
-            
+            {
+                if let Some(hysteresis) = alarm.config.hysteresis {
+                    should_activate =
+                        self.apply_hysteresis(alarm, should_activate, &signal_value, hysteresis);
+                }
+            }
+
             match (alarm.state, should_activate) {
                 (AlarmState::Normal, true) => {
                     #[cfg(feature = "alarm-delay")]
@@ -360,8 +409,8 @@ impl AlarmManager {
                             continue;
                         }
                     }
-                    
-                    self.activate_alarm(alarm).await?;
+
+                    to_activate.push(idx);
                 }
                 (AlarmState::Active, false) => {
                     #[cfg(feature = "alarm-delay")]
@@ -375,8 +424,8 @@ impl AlarmManager {
                             continue;
                         }
                     }
-                    
-                    self.deactivate_alarm(alarm).await?;
+
+                    to_deactivate.push(idx);
                 }
                 _ => {
                     #[cfg(feature = "alarm-delay")]
@@ -386,24 +435,38 @@ impl AlarmManager {
                 }
             }
         }
-        
+
+        #[cfg(feature = "alarm-shelving")]
+        for idx in to_unshelve {
+            if let Some(alarm) = self.alarms.get_mut(idx) {
+                alarm.shelved_until = None;
+                alarm.state = AlarmState::Normal;
+                let _ = self
+                    .tx
+                    .send(AlarmEvent::Unshelved {
+                        name: alarm.config.name.clone(),
+                    })
+                    .await;
+            }
+        }
+
+        for idx in to_activate {
+            self.activate_alarm_by_index(idx).await?;
+        }
+
+        for idx in to_deactivate {
+            self.deactivate_alarm_by_index(idx).await?;
+        }
+
         Ok(())
     }
-    
+
     fn evaluate_condition(&self, condition: &AlarmCondition, value: &Value) -> Result<bool> {
         Ok(match condition {
-            AlarmCondition::High { threshold } => {
-                value.as_float().unwrap_or(0.0) > *threshold
-            }
-            AlarmCondition::Low { threshold } => {
-                value.as_float().unwrap_or(0.0) < *threshold
-            }
-            AlarmCondition::Equal { value: ref_value } => {
-                value == ref_value
-            }
-            AlarmCondition::NotEqual { value: ref_value } => {
-                value != ref_value
-            }
+            AlarmCondition::High { threshold } => value.as_float().unwrap_or(0.0) > *threshold,
+            AlarmCondition::Low { threshold } => value.as_float().unwrap_or(0.0) < *threshold,
+            AlarmCondition::Equal { value: ref_value } => value == ref_value,
+            AlarmCondition::NotEqual { value: ref_value } => value != ref_value,
             AlarmCondition::InRange { min, max } => {
                 let v = value.as_float().unwrap_or(0.0);
                 v >= *min && v <= *max
@@ -413,12 +476,17 @@ impl AlarmManager {
                 v < *min || v > *max
             }
             #[cfg(feature = "extended-alarms")]
-            AlarmCondition::RateOfChange { max_change_per_second } => {
+            AlarmCondition::RateOfChange {
+                max_change_per_second,
+            } => {
                 // Would need to track previous values
                 false // Placeholder
             }
             #[cfg(feature = "extended-alarms")]
-            AlarmCondition::Deviation { reference_signal, max_deviation } => {
+            AlarmCondition::Deviation {
+                reference_signal,
+                max_deviation,
+            } => {
                 if let Some(ref_value) = self.bus.get(reference_signal) {
                     let v = value.as_float().unwrap_or(0.0);
                     let ref_v = ref_value.as_float().unwrap_or(0.0);
@@ -439,9 +507,15 @@ impl AlarmManager {
             }
         })
     }
-    
+
     #[cfg(feature = "alarm-hysteresis")]
-    fn apply_hysteresis(&self, alarm: &Alarm, should_activate: bool, value: &Value, hysteresis: f64) -> bool {
+    fn apply_hysteresis(
+        &self,
+        alarm: &Alarm,
+        should_activate: bool,
+        value: &Value,
+        hysteresis: f64,
+    ) -> bool {
         match (&alarm.config.condition, alarm.state) {
             (AlarmCondition::High { threshold }, AlarmState::Active) => {
                 // Deactivate only if value drops below threshold - hysteresis
@@ -451,39 +525,44 @@ impl AlarmManager {
                 // Deactivate only if value rises above threshold + hysteresis
                 value.as_float().unwrap_or(0.0) < (*threshold + hysteresis)
             }
-            _ => should_activate
+            _ => should_activate,
         }
     }
-    
+
     async fn activate_alarm(&mut self, alarm: &mut Alarm) -> Result<()> {
         alarm.state = AlarmState::Active;
         alarm.last_transition = Utc::now();
-        
+
         #[cfg(feature = "alarm-history")]
         {
             alarm.activation_count += 1;
         }
-        
+
         #[cfg(feature = "alarm-acknowledgment")]
         {
             alarm.acknowledged = false;
             alarm.acknowledged_by = None;
             alarm.acknowledged_at = None;
         }
-        
-        info!("Alarm '{}' activated - severity: {:?}", 
-              alarm.config.name, alarm.config.severity);
-        
-        let _ = self.tx.send(AlarmEvent::Activated {
-            name: alarm.config.name.clone(),
-            severity: alarm.config.severity,
-        }).await;
-        
+
+        info!(
+            "Alarm '{}' activated - severity: {:?}",
+            alarm.config.name, alarm.config.severity
+        );
+
+        let _ = self
+            .tx
+            .send(AlarmEvent::Activated {
+                name: alarm.config.name.clone(),
+                severity: alarm.config.severity,
+            })
+            .await;
+
         #[cfg(feature = "alarm-actions")]
         for action in &alarm.config.actions {
             self.action_executor.execute(action, &alarm.config).await?;
         }
-        
+
         #[cfg(feature = "alarm-history")]
         self.add_history_entry(AlarmHistoryEntry {
             timestamp: Utc::now(),
@@ -493,29 +572,34 @@ impl AlarmManager {
             value: alarm.last_value.clone(),
             user: None,
         });
-        
+
         #[cfg(feature = "alarm-statistics")]
         {
             self.statistics.total_activations += 1;
             self.statistics.active_count += 1;
-            *self.statistics.activations_by_severity
+            *self
+                .statistics
+                .activations_by_severity
                 .entry(alarm.config.severity)
                 .or_insert(0) += 1;
         }
-        
+
         Ok(())
     }
-    
+
     async fn deactivate_alarm(&mut self, alarm: &mut Alarm) -> Result<()> {
         alarm.state = AlarmState::Normal;
         alarm.last_transition = Utc::now();
-        
+
         info!("Alarm '{}' deactivated", alarm.config.name);
-        
-        let _ = self.tx.send(AlarmEvent::Deactivated {
-            name: alarm.config.name.clone(),
-        }).await;
-        
+
+        let _ = self
+            .tx
+            .send(AlarmEvent::Deactivated {
+                name: alarm.config.name.clone(),
+            })
+            .await;
+
         #[cfg(feature = "alarm-history")]
         self.add_history_entry(AlarmHistoryEntry {
             timestamp: Utc::now(),
@@ -525,15 +609,29 @@ impl AlarmManager {
             value: alarm.last_value.clone(),
             user: None,
         });
-        
+
         #[cfg(feature = "alarm-statistics")]
         {
             self.statistics.active_count = self.statistics.active_count.saturating_sub(1);
         }
-        
+
         Ok(())
     }
-    
+
+    async fn activate_alarm_by_index(&mut self, idx: usize) -> Result<()> {
+        if let Some(alarm) = self.alarms.get_mut(idx) {
+            self.activate_alarm(alarm).await?;
+        }
+        Ok(())
+    }
+
+    async fn deactivate_alarm_by_index(&mut self, idx: usize) -> Result<()> {
+        if let Some(alarm) = self.alarms.get_mut(idx) {
+            self.deactivate_alarm(alarm).await?;
+        }
+        Ok(())
+    }
+
     async fn handle_event(&mut self, event: AlarmEvent) -> Result<()> {
         match event {
             #[cfg(feature = "alarm-acknowledgment")]
@@ -542,7 +640,7 @@ impl AlarmManager {
                     alarm.acknowledged = true;
                     alarm.acknowledged_by = Some(by.clone());
                     alarm.acknowledged_at = Some(Utc::now());
-                    
+
                     #[cfg(feature = "alarm-history")]
                     self.add_history_entry(AlarmHistoryEntry {
                         timestamp: Utc::now(),
@@ -554,14 +652,14 @@ impl AlarmManager {
                     });
                 }
             }
-            
+
             #[cfg(feature = "alarm-shelving")]
             AlarmEvent::Shelved { name, until } => {
                 if let Some(alarm) = self.alarms.iter_mut().find(|a| a.config.name == name) {
                     if alarm.config.can_shelve {
                         alarm.shelved_until = Some(until);
                         alarm.state = AlarmState::Shelved;
-                        
+
                         #[cfg(feature = "alarm-history")]
                         self.add_history_entry(AlarmHistoryEntry {
                             timestamp: Utc::now(),
@@ -574,13 +672,13 @@ impl AlarmManager {
                     }
                 }
             }
-            
+
             _ => {}
         }
-        
+
         Ok(())
     }
-    
+
     #[cfg(feature = "alarm-history")]
     fn add_history_entry(&mut self, entry: AlarmHistoryEntry) {
         self.history.events.push(entry);
@@ -588,7 +686,7 @@ impl AlarmManager {
             self.history.events.remove(0);
         }
     }
-    
+
     #[cfg(feature = "alarm-persistence")]
     fn load_state(&mut self) -> Result<()> {
         if let Some(path) = &self.persistence_path {
@@ -597,7 +695,7 @@ impl AlarmManager {
         }
         Ok(())
     }
-    
+
     #[cfg(feature = "alarm-persistence")]
     fn save_state(&self) -> Result<()> {
         if let Some(path) = &self.persistence_path {
@@ -606,33 +704,38 @@ impl AlarmManager {
         }
         Ok(())
     }
-    
+
     // Public API methods
     pub fn get_active_alarms(&self) -> Vec<&Alarm> {
-        self.alarms.iter()
+        self.alarms
+            .iter()
             .filter(|a| a.state == AlarmState::Active)
             .collect()
     }
-    
+
     #[cfg(feature = "alarm-acknowledgment")]
     pub async fn acknowledge_alarm(&mut self, name: &str, user: &str) -> Result<()> {
-        self.tx.send(AlarmEvent::Acknowledged {
-            name: name.to_string(),
-            by: user.to_string(),
-        }).await
+        self.tx
+            .send(AlarmEvent::Acknowledged {
+                name: name.to_string(),
+                by: user.to_string(),
+            })
+            .await
             .map_err(|e| PlcError::Runtime(format!("Failed to send acknowledge event: {}", e)))
     }
-    
+
     #[cfg(feature = "alarm-shelving")]
     pub async fn shelve_alarm(&mut self, name: &str, duration_minutes: u32) -> Result<()> {
         let until = Utc::now() + chrono::Duration::minutes(duration_minutes as i64);
-        self.tx.send(AlarmEvent::Shelved {
-            name: name.to_string(),
-            until,
-        }).await
+        self.tx
+            .send(AlarmEvent::Shelved {
+                name: name.to_string(),
+                until,
+            })
+            .await
             .map_err(|e| PlcError::Runtime(format!("Failed to send shelve event: {}", e)))
     }
-    
+
     #[cfg(feature = "alarm-history")]
     pub fn get_history(&self, limit: Option<usize>) -> &[AlarmHistoryEntry] {
         let len = self.history.events.len();
@@ -641,7 +744,7 @@ impl AlarmManager {
             _ => &self.history.events,
         }
     }
-    
+
     #[cfg(feature = "alarm-statistics")]
     pub fn get_statistics(&self) -> AlarmStatisticsReport {
         AlarmStatisticsReport {
@@ -656,7 +759,7 @@ impl AlarmManager {
 struct ActionExecutor {
     #[cfg(feature = "email")]
     email_client: Option<lettre::AsyncSmtpTransport<lettre::Tokio1Executor>>,
-    
+
     #[cfg(feature = "web")]
     http_client: reqwest::Client,
 }
@@ -667,32 +770,39 @@ impl ActionExecutor {
         Self {
             #[cfg(feature = "email")]
             email_client: None,
-            
+
             #[cfg(feature = "web")]
             http_client: reqwest::Client::new(),
         }
     }
-    
+
     async fn execute(&self, action: &AlarmAction, alarm: &AlarmConfig) -> Result<()> {
         match action {
             #[cfg(feature = "email")]
-            AlarmAction::Email { recipients, template } => {
+            AlarmAction::Email {
+                recipients,
+                template,
+            } => {
                 // Send email implementation
             }
-            
+
             AlarmAction::Signal { name, value } => {
                 // Set signal value
             }
-            
+
             AlarmAction::Command { command, args } => {
                 // Execute command
             }
-            
+
             #[cfg(feature = "web")]
-            AlarmAction::Webhook { url, method, headers } => {
+            AlarmAction::Webhook {
+                url,
+                method,
+                headers,
+            } => {
                 // Send webhook
             }
-            
+
             _ => {}
         }
         Ok(())
@@ -710,17 +820,28 @@ pub struct AlarmStatisticsReport {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_alarm_condition_evaluation() {
         let manager = AlarmManager::new(vec![], SignalBus::new()).unwrap();
-        
+
         let high_condition = AlarmCondition::High { threshold: 50.0 };
-        assert!(manager.evaluate_condition(&high_condition, &Value::Float(60.0)).unwrap());
-        assert!(!manager.evaluate_condition(&high_condition, &Value::Float(40.0)).unwrap());
-        
-        let range_condition = AlarmCondition::InRange { min: 10.0, max: 20.0 };
-        assert!(manager.evaluate_condition(&range_condition, &Value::Float(15.0)).unwrap());
-        assert!(!manager.evaluate_condition(&range_condition, &Value::Float(25.0)).unwrap());
+        assert!(manager
+            .evaluate_condition(&high_condition, &Value::Float(60.0))
+            .unwrap());
+        assert!(!manager
+            .evaluate_condition(&high_condition, &Value::Float(40.0))
+            .unwrap());
+
+        let range_condition = AlarmCondition::InRange {
+            min: 10.0,
+            max: 20.0,
+        };
+        assert!(manager
+            .evaluate_condition(&range_condition, &Value::Float(15.0))
+            .unwrap());
+        assert!(!manager
+            .evaluate_condition(&range_condition, &Value::Float(25.0))
+            .unwrap());
     }
 }


### PR DESCRIPTION
## Summary
- avoid multiple borrows in alarm processing
- add helpers to activate/deactivate alarms by index

## Testing
- `cargo clippy --all-features -- -D warnings` *(failed: component build was interrupted)*
- `cargo test --all-features -- --test-threads=1` *(failed: build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68636c284374832c90cced3ae5930fca