### PR TITLE
Fix build issues with new protocol module

### DIFF
--- a/src/protocols/modbus.rs
+++ b/src/protocols/modbus.rs
@@ -1,0 +1,1 @@
+pub use crate::modbus::*;

--- a/src/protocols/mqtt.rs
+++ b/src/protocols/mqtt.rs
@@ -1,0 +1,1 @@
+pub use crate::mqtt::*;

--- a/src/protocols/opcua.rs
+++ b/src/protocols/opcua.rs
@@ -1,0 +1,1 @@
+pub use crate::opcua::*;

--- a/src/protocols/s7.rs
+++ b/src/protocols/s7.rs
@@ -1,0 +1,1 @@
+pub use crate::s7::*;


### PR DESCRIPTION
## Summary
- add stub modules under `protocols` to re-export existing protocol implementations
- convert configuration struct into `MqttConfig`
- mark `MqttClient` as `Send`/`Sync`
- adjust `main` to use new API

## Testing
- `cargo check --features mqtt --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68646465c610832c8dad45a1486c9498