### PR TITLE
Fix feature dependency syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ scada = ["s7-support", "modbus-support", "opcua-support", "production"]
 # Validation features
 basic-validation = ["validation"]
 regex-validation = ["validation", "regex", "once_cell"]
-schema-validation = ["validation", "jsonschema"]
+schema-validation = ["validation", "dep:jsonschema"]
 custom-validation = ["validation"]
 composite-validation = ["validation"]
 cross-field-validation = ["composite-validation"]


### PR DESCRIPTION
## Summary
- fix schema-validation feature definition

## Testing
- `cargo check` *(fails: failed to select a version for `opcua`)*

------
https://chatgpt.com/codex/tasks/task_e_6864ccfaa2c0832ca960de8a089f8035