### PR TITLE
Fix opcua dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ lz4 = { version = "1.28", optional = true }
 # Communication protocols
 rust-snap7 = { version = "1.0", optional = true }
 tokio-modbus = { version = "0.15", optional = true }
-opcua = { version = "0.13", optional = true }
+opcua = { version = "0.12", optional = true }
 rumqttc = { version = "0.24", optional = true }
 paho-mqtt = { version = "0.12", optional = true }
 


### PR DESCRIPTION
## Summary
- correct OPC UA dependency version to 0.12

## Testing
- `cargo update -p opcua --precise 0.12.0`
- `cargo check --locked --quiet` *(fails: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6864d2c1e2cc832c87778135eedd7f7c