### PR TITLE
Add missing modules and fix clippy warnings

### DIFF
--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -267,36 +267,55 @@ pub fn create_block(config: &BlockConfig) -> Result<Box<dyn Block>> {
 
 /// Get list of all available block types
 pub fn get_available_block_types() -> Vec<&'static str> {
-    let mut types = vec![
+    let types = vec![
         // Always available
         "AND", "OR", "NOT", "XOR",
         "GT", "LT", "GTE", "LTE", "EQ", "NEQ",
         "ON_DELAY", "OFF_DELAY", "PULSE",
         "ADD", "SUB", "MUL", "DIV",
         "SCALE", "LIMIT", "SELECT", "MUX", "DEMUX", "DATA_GENERATOR",
+        #[cfg(feature = "edge-detection")]
+        "RISING_EDGE",
+        #[cfg(feature = "edge-detection")]
+        "FALLING_EDGE",
+        #[cfg(feature = "edge-detection")]
+        "CHANGE_DETECT",
+        #[cfg(feature = "memory-blocks")]
+        "SR_LATCH",
+        #[cfg(feature = "memory-blocks")]
+        "D_FLIPFLOP",
+        #[cfg(feature = "memory-blocks")]
+        "JK_FLIPFLOP",
+        #[cfg(feature = "memory-blocks")]
+        "T_FLIPFLOP",
+        #[cfg(feature = "pid-control")]
+        "PID",
+        #[cfg(feature = "pid-control")]
+        "TUNE_PID",
+        #[cfg(feature = "communication")]
+        "MODBUS_READ",
+        #[cfg(feature = "communication")]
+        "MODBUS_WRITE",
+        #[cfg(feature = "communication")]
+        "TCP_CLIENT",
+        #[cfg(feature = "communication")]
+        "UDP_SEND",
+        #[cfg(feature = "state-machine")]
+        "STATE_MACHINE",
+        #[cfg(feature = "state-machine")]
+        "SEQUENCE",
+        #[cfg(feature = "advanced-math")]
+        "FFT",
+        #[cfg(feature = "advanced-math")]
+        "FILTER",
+        #[cfg(feature = "advanced-math")]
+        "STATISTICS",
+        #[cfg(feature = "ml")]
+        "ML_INFERENCE",
+        #[cfg(feature = "ml")]
+        "ANOMALY_DETECT",
     ];
-    
-    #[cfg(feature = "edge-detection")]
-    types.extend_from_slice(&["RISING_EDGE", "FALLING_EDGE", "CHANGE_DETECT"]);
-    
-    #[cfg(feature = "memory-blocks")]
-    types.extend_from_slice(&["SR_LATCH", "D_FLIPFLOP", "JK_FLIPFLOP", "T_FLIPFLOP"]);
-    
-    #[cfg(feature = "pid-control")]
-    types.extend_from_slice(&["PID", "TUNE_PID"]);
-    
-    #[cfg(feature = "communication")]
-    types.extend_from_slice(&["MODBUS_READ", "MODBUS_WRITE", "TCP_CLIENT", "UDP_SEND"]);
-    
-    #[cfg(feature = "state-machine")]
-    types.extend_from_slice(&["STATE_MACHINE", "SEQUENCE"]);
-    
-    #[cfg(feature = "advanced-math")]
-    types.extend_from_slice(&["FFT", "FILTER", "STATISTICS"]);
-    
-    #[cfg(feature = "ml")]
-    types.extend_from_slice(&["ML_INFERENCE", "ANOMALY_DETECT"]);
-    
+
     types
 }
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -108,7 +108,7 @@ impl HistoryManager {
             })
             .build();
         
-        let mut manager = Self {
+        let manager = Self {
             config,
             buffer: Arc::new(RwLock::new(Vec::new())),
             tx,

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -9,7 +9,7 @@ use rumqttc::{AsyncClient, Event, EventLoop, MqttOptions, QoS, Packet};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tracing::{info, warn, error, debug, trace};
+use tracing::{info, error, debug, trace};
 
 #[cfg(feature = "mqtt-persistence")]
 use std::path::PathBuf;
@@ -536,13 +536,13 @@ impl MqttClient {
     }
     
     /// Parse MQTT payload into a PETRA Value - FIXED VERSION
-    fn parse_payload(&self, payload: &[u8], sub: &MqttSubscription) -> Result<Value> {
+    fn parse_payload(&self, payload: &[u8], _sub: &MqttSubscription) -> Result<Value> {
         let text = std::str::from_utf8(payload)
             .map_err(|e| PlcError::Mqtt(format!("Invalid UTF-8 in payload: {}", e)))?;
         
         // Apply data transformation if configured
         #[cfg(feature = "validation")]
-        if let Some(transform) = &sub.transform {
+        if let Some(transform) = &_sub.transform {
             return self.apply_transform(text, transform);
         }
         

--- a/src/storage/advanced.rs
+++ b/src/storage/advanced.rs
@@ -1,0 +1,16 @@
+//! Advanced storage backends module
+
+use crate::error::Result;
+
+// Re-export any advanced storage functionality if it exists elsewhere
+// For now, just create a placeholder
+
+pub struct AdvancedStorageManager {
+    // Implementation details
+}
+
+impl AdvancedStorageManager {
+    pub fn new() -> Self {
+        Self {}
+    }
+}

--- a/src/value.rs
+++ b/src/value.rs
@@ -175,7 +175,6 @@ impl Value {
             Value::QualityValue { value, quality, .. } if quality.is_good() => {
                 value.as_bool()
             }
-            _ => None,
         }
     }
     
@@ -197,7 +196,6 @@ impl Value {
             Value::QualityValue { value, quality, .. } if quality.is_good() => {
                 value.as_int()
             }
-            _ => None,
         }
     }
     
@@ -215,7 +213,6 @@ impl Value {
             Value::QualityValue { value, quality, .. } if quality.is_good() => {
                 value.as_float()
             }
-            _ => None,
         }
     }
     

--- a/src/web/health.rs
+++ b/src/web/health.rs
@@ -1,0 +1,4 @@
+//! Health endpoint module re-export
+
+// Re-export the health module from the parent
+pub use crate::health::*;


### PR DESCRIPTION
## Summary
- add placeholder `AdvancedStorageManager` module
- expose health APIs via `web::health`
- clean up unused imports and parameters
- fix `get_available_block_types` without mutating vector
- tidy `Value` conversions

## Testing
- `cargo build --lib --features "mqtt,history,security,metrics,basic-auth"`

------
https://chatgpt.com/codex/tasks/task_e_686607990dd4832c9ca0188bd9cdbd9e