### PR TITLE
Fix clang linker path

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,7 +15,7 @@ opt-level = 2
 
 # Use faster linker (if available)
 [target.x86_64-unknown-linux-gnu]
-linker = "clang"
+linker = "clang++"
 rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 
 [target.x86_64-pc-windows-msvc]


### PR DESCRIPTION
## Summary
- use `clang++` as the linker so that libstdc++ can be found automatically

## Testing
- `cargo build --release`

------
https://chatgpt.com/codex/tasks/task_e_68661724b6ac832caa5025439d06783e