### PR TITLE
Fix value conversion benches

### DIFF
--- a/benches/engine.rs
+++ b/benches/engine.rs
@@ -200,8 +200,8 @@ fn benchmark_value_operations(c: &mut Criterion) {
         let bool_val = Value::Bool(true);
         
         b.iter(|| {
-            black_box(float_val.as_f64());
-            black_box(int_val.as_i64());
+            black_box(float_val.as_float());
+            black_box(int_val.as_int());
             black_box(bool_val.as_bool());
         });
     });

--- a/benches/engine_performance.rs
+++ b/benches/engine_performance.rs
@@ -297,8 +297,8 @@ fn benchmark_value_operations(c: &mut Criterion) {
         let bool_val = Value::Bool(true);
 
         b.iter(|| {
-            let _ = black_box(float_val.as_f64());
-            let _ = black_box(int_val.as_i64());
+            let _ = black_box(float_val.as_float());
+            let _ = black_box(int_val.as_int());
             let _ = black_box(bool_val.as_bool());
         });
     });


### PR DESCRIPTION
## Summary
- update `bench` code to use `as_float` and `as_int`

## Testing
- `cargo check --bench engine_performance`
- `cargo test --no-run`


------
https://chatgpt.com/codex/tasks/task_e_6866eb104c2c832c9a7964fa38df07ef