### PR TITLE
Add missing value conversion methods

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -198,6 +198,11 @@ impl Value {
             }
         }
     }
+
+    /// Alias for [`Self::as_int`].
+    pub fn as_i64(&self) -> Option<i64> {
+        self.as_int()
+    }
     
     /// Convert to float if possible
     pub fn as_float(&self) -> Option<f64> {
@@ -214,6 +219,11 @@ impl Value {
                 value.as_float()
             }
         }
+    }
+
+    /// Alias for [`Self::as_float`].
+    pub fn as_f64(&self) -> Option<f64> {
+        self.as_float()
     }
     
     /// Convert to string representation


### PR DESCRIPTION
## Summary
- implement `as_i64` and `as_f64` as compatibility helpers

## Testing
- `cargo test --release -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_6866ecf3c6f8832c83ffd54b93b869cc