### PR TITLE
Sync MQTT configuration structs

### DIFF
--- a/src/config_manager.rs
+++ b/src/config_manager.rs
@@ -188,18 +188,7 @@ impl Validatable for BlockConfig {
 
 impl Validatable for MqttConfig {
     fn validate(&self) -> Result<()> {
-        validators::validate_url(&format!("tcp://{}:{}", self.host, self.port))?;
-        validators::validate_port(self.port)?;
-        
-        if self.client_id.is_empty() {
-            return Err(PlcError::Config("MQTT client ID cannot be empty".to_string()));
-        }
-        
-        if self.qos > 2 {
-            return Err(PlcError::Config("MQTT QoS must be 0, 1, or 2".to_string()));
-        }
-        
-        Ok(())
+        crate::config::MqttConfig::validate(self)
     }
 }
 
@@ -865,14 +854,21 @@ mod tests {
     #[test]
     fn test_mqtt_validation() {
         let mqtt = MqttConfig {
-            enabled: true,
             host: "localhost".to_string(),
             port: 0, // Invalid
             client_id: "test".to_string(),
             username: None,
             password: None,
+            keepalive_secs: 60,
+            timeout_ms: 1000,
+            use_tls: false,
             qos: 1,
             retain: false,
+            subscribe_topics: Vec::new(),
+            publish_topic_base: None,
+            auto_reconnect: true,
+            max_reconnect_attempts: 0,
+            reconnect_delay_secs: 5,
         };
         
         assert!(mqtt.validate().is_err());

--- a/src/mqtt.rs
+++ b/src/mqtt.rs
@@ -24,6 +24,29 @@ use std::fs::File;
 // CONFIGURATION STRUCTURES
 // ============================================================================
 
+/// MQTT client internal configuration
+///
+/// This is the internal MQTT configuration used by the MQTT client.
+/// It's converted from the user-facing `MqttConfig` in `config.rs`.
+#[derive(Debug, Clone)]
+pub struct InternalMqttConfig {
+    pub broker_host: String,
+    pub broker_port: u16,
+    pub client_id: String,
+    pub username: Option<String>,
+    pub password: Option<String>,
+    pub keepalive_secs: u16,
+    pub timeout_ms: u64,
+    pub use_tls: bool,
+    pub qos: u8,
+    pub retain: bool,
+    pub subscribe_topics: Vec<String>,
+    pub publish_topic_base: Option<String>,
+    pub auto_reconnect: bool,
+    pub max_reconnect_attempts: u32,
+    pub reconnect_delay_secs: u64,
+}
+
 /// MQTT client configuration
 /// 
 /// This structure defines the MQTT client settings and is compatible with
@@ -249,32 +272,24 @@ pub enum BridgeDirection {
 
 /// Conversion from the main config structure to MQTT-specific config
 /// This maintains compatibility with the unified configuration system
-impl From<crate::config::MqttConfig> for MqttConfig {
+impl From<crate::config::MqttConfig> for InternalMqttConfig {
     fn from(cfg: crate::config::MqttConfig) -> Self {
         Self {
-            broker_host: cfg.host.clone(),
+            broker_host: cfg.host,
             broker_port: cfg.port,
             client_id: cfg.client_id,
             username: cfg.username,
             password: cfg.password,
-            keep_alive_secs: cfg.keepalive_secs,
-            clean_session: cfg.clean_session,
-            subscriptions: Vec::new(), // Would need to be configured separately
-            publications: Vec::new(),  // Would need to be configured separately
-            #[cfg(feature = "mqtt-persistence")]
-            persistence_path: None,
-            #[cfg(feature = "mqtt-tls")]
-            tls: cfg.tls.map(|t| TlsConfig {
-                ca_cert: t.ca_cert,
-                client_cert: t.client_cert,
-                client_key: t.client_key,
-                alpn_protocols: None,
-                insecure: false,
-            }),
-            #[cfg(feature = "mqtt-5")]
-            mqtt5_properties: None,
-            #[cfg(feature = "mqtt-bridge")]
-            bridge_config: None,
+            keepalive_secs: cfg.keepalive_secs,
+            timeout_ms: cfg.timeout_ms,
+            use_tls: cfg.use_tls,
+            qos: cfg.qos,
+            retain: cfg.retain,
+            subscribe_topics: cfg.subscribe_topics,
+            publish_topic_base: cfg.publish_topic_base,
+            auto_reconnect: cfg.auto_reconnect,
+            max_reconnect_attempts: cfg.max_reconnect_attempts,
+            reconnect_delay_secs: cfg.reconnect_delay_secs,
         }
     }
 }

--- a/tests/integration/resilience_test.rs
+++ b/tests/integration/resilience_test.rs
@@ -7,12 +7,21 @@ async fn test_mqtt_broker_reconnection() {
     // This test requires mosquitto to be running
     let config = Config {
         mqtt: Some(MqttConfig {
-            broker_host: "localhost".to_string(),
-            broker_port: 1883,
+            host: "localhost".to_string(),
+            port: 1883,
             client_id: "test-resilience".to_string(),
-            reconnect_interval_ms: Some(100),
-            max_reconnect_attempts: Some(5),
-            ..Default::default()
+            username: None,
+            password: None,
+            keepalive_secs: 60,
+            timeout_ms: 5000,
+            use_tls: false,
+            qos: 0,
+            retain: false,
+            subscribe_topics: Vec::new(),
+            publish_topic_base: None,
+            auto_reconnect: true,
+            max_reconnect_attempts: 5,
+            reconnect_delay_secs: 1,
         }),
         scan_time_ms: 100,
         ..Default::default()


### PR DESCRIPTION
## Summary
- update MqttConfig structure in `config.rs`
- implement defaults and validation helpers
- expose InternalMqttConfig and conversion in `mqtt.rs`
- adjust validation utilities and tests
- adapt resilience test to new fields

## Testing
- `cargo test --no-run` *(fails: invalid inline table in Cargo.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68676fd90710832cb8c22c448306abbf