### PR TITLE
Add parallelization metadata methods

### DIFF
--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -142,6 +142,21 @@ pub trait Block: Send + Sync {
     fn state(&self) -> HashMap<String, Value> {
         HashMap::new()
     }
+
+    /// Get input dependencies for this block
+    fn input_dependencies(&self) -> Vec<&str> {
+        vec![]
+    }
+
+    /// Get output signals this block writes
+    fn output_signals(&self) -> Vec<&str> {
+        vec![]
+    }
+
+    /// Can this block be executed in parallel with others?
+    fn is_parallelizable(&self) -> bool {
+        true
+    }
 }
 
 /// Block factory function - creates blocks based on configuration


### PR DESCRIPTION
## Summary
- add `input_dependencies`, `output_signals`, and `is_parallelizable` methods to the `Block` trait

## Testing
- `cargo test` *(fails: invalid inline table in Cargo.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68677c407d44832c89e5182d54bd44a0