### PR TITLE
Add parallel-execution feature with num_cpus dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,10 @@ futures = {
     default-features = false 
 }  # Future utilities
 rand = "0.8"             # Random number generation (used in testing/simulation)
+num_cpus = {
+    version = "1.16",
+    optional = true
+}
 
 # ================================================================================
 # PROTOCOL DEPENDENCIES
@@ -543,6 +547,7 @@ development = [
 # === PERFORMANCE ===
 optimized = []                # Use parking_lot and optimized algorithms
 realtime = []                 # Real-time OS scheduling (Linux only)
+parallel-execution = ["tokio/rt-multi-thread", "num_cpus"]
 
 # === CONNECTIVITY ===
 mqtt = ["dep:rumqttc"]       # MQTT protocol support


### PR DESCRIPTION
## Summary
- add optional `num_cpus` dependency
- introduce `parallel-execution` feature using `tokio/rt-multi-thread` and `num_cpus`

## Testing
- `./scripts/test.sh quick` *(fails: invalid inline table in Cargo.toml)*

------
https://chatgpt.com/codex/tasks/task_e_68677c794c24832caaba67a29b51871e