### PR TITLE
Add feature-aware benchmarks

### DIFF
--- a/benches/engine_performance.rs
+++ b/benches/engine_performance.rs
@@ -1,13 +1,74 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::sync::Once;
 
-fn minimal_benchmark(c: &mut Criterion) {
+mod features;
+
+static PRINT_FEATURES: Once = Once::new();
+
+fn print_features_once() {
+    PRINT_FEATURES.call_once(features::print_enabled_features);
+}
+
+// Basic benchmark that always works
+fn simple_test(c: &mut Criterion) {
+    print_features_once();
     c.bench_function("simple_test", |b| {
         b.iter(|| {
             let x = 2 + 2;
-            criterion::black_box(x);
+            black_box(x);
         });
     });
 }
 
-criterion_group!(benches, minimal_benchmark);
-criterion_main!(benches);
+// PETRA-specific benchmarks
+fn petra_value_benchmark(c: &mut Criterion) {
+    print_features_once();
+    use petra::Value;
+
+    c.bench_function("value_creation", |b| {
+        b.iter(|| {
+            let val = Value::Float(42.0);
+            black_box(val);
+        });
+    });
+}
+
+fn signal_bus_benchmark(c: &mut Criterion) {
+    print_features_once();
+    use petra::{SignalBus, Value};
+
+    c.bench_function("signal_operations", |b| {
+        let bus = SignalBus::new();
+        b.iter(|| {
+            let _ = bus.set("test", Value::Float(1.0));
+            let val = bus.get("test").unwrap_or(Value::Float(0.0));
+            black_box(val);
+        });
+    });
+}
+
+// Diagnostic benchmark for feature visibility
+fn diagnostic_benchmark(c: &mut Criterion) {
+    print_features_once();
+    c.bench_function("feature_diagnostic", |b| {
+        b.iter(|| {
+            #[cfg(feature = "extended-types")]
+            let extended = true;
+            #[cfg(not(feature = "extended-types"))]
+            let extended = false;
+
+            black_box(extended);
+        });
+    });
+}
+
+// Configure benchmark groups depending on available features
+criterion_group!(
+    petra_benches,
+    simple_test,
+    petra_value_benchmark,
+    signal_bus_benchmark,
+    diagnostic_benchmark
+);
+
+criterion_main!(petra_benches);

--- a/benches/features.rs
+++ b/benches/features.rs
@@ -1,0 +1,17 @@
+// Feature detection helpers for benchmarks
+
+#[cfg(feature = "extended-types")]
+pub const HAS_EXTENDED_TYPES: bool = true;
+#[cfg(not(feature = "extended-types"))]
+pub const HAS_EXTENDED_TYPES: bool = false;
+
+#[cfg(feature = "enhanced-monitoring")]
+pub const HAS_MONITORING: bool = true;
+#[cfg(not(feature = "enhanced-monitoring"))]
+pub const HAS_MONITORING: bool = false;
+
+pub fn print_enabled_features() {
+    println!("Benchmark features:");
+    println!("  Extended types: {}", HAS_EXTENDED_TYPES);
+    println!("  Enhanced monitoring: {}", HAS_MONITORING);
+}


### PR DESCRIPTION
## Summary
- add helper for detecting enabled features in `benches/features.rs`
- update `engine_performance` benchmark to print enabled features and include PETRA-specific benches

## Testing
- `cargo bench --bench engine_performance --no-default-features -- --warm-up-time 0.5 --measurement-time 1`
- `cargo bench --bench engine_performance -- --warm-up-time 0.5 --measurement-time 1` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_6867f9bc8dc4832cabcea822a4c36b5a