### PR TITLE
Fix bench build by enabling tracing features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ tracing = "0.1"          # Structured, async-aware logging
 chrono = { version = "0.4", features = ["serde"] }  # Date/time handling (timestamps)
 clap = { version = "4.5", features = ["derive"], optional = true }
 colored = { version = "2.0", optional = true }
-tracing-subscriber = { version = "0.3", optional = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"], optional = true }
 num_cpus = { version = "1.16", optional = true }
 libc = { version = "0.2", optional = true }
 uuid = { version = "1.10", features = ["v4", "serde"] }  # Unique identifiers


### PR DESCRIPTION
## Summary
- enable env-filter, fmt and json features for tracing-subscriber
- run benchmark suite without default features

## Testing
- `cargo bench --no-default-features --bench engine_performance`

------
https://chatgpt.com/codex/tasks/task_e_686855b70fc4832cae891037fab39ad3