### PR TITLE
Add flexible benchmark scripts and docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,8 +274,9 @@ chrono = "0.4"  # Used by build.rs for build timestamp generation
 # Dependencies used only for testing and development
 
 [dev-dependencies]
-criterion = { version = "0.5", default-features = false }      # Benchmarking framework
+criterion = { version = "0.4", features = ["html_reports"] }      # Benchmarking framework
 proptest = "1.4"                                                # Property-based testing
+tokio = { version = "1.0", features = ["rt", "rt-multi-thread"] } # Runtime for async benchmarks
 tokio-test = "0.4"                                              # Tokio testing utilities
 tempfile = "3.10"                                               # Temporary file creation
 mockall = "0.12"                                                # Mock object generation

--- a/benches/engine_performance.rs
+++ b/benches/engine_performance.rs
@@ -1,74 +1,313 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use std::sync::Once;
+//! Enhanced Engine performance benchmarks with configurable signal counts
 
-mod features;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use petra::config::{BlockConfig, SignalConfig, Config};
+use petra::{Engine, SignalBus, Value};
+use std::collections::HashMap;
+use std::env;
+use std::time::Duration;
+use tokio::runtime::Runtime;
 
-static PRINT_FEATURES: Once = Once::new();
-
-fn print_features_once() {
-    PRINT_FEATURES.call_once(features::print_enabled_features);
+/// Parse signal/block counts from environment variables or use defaults
+fn parse_counts(env_var: &str, default: &str) -> Vec<usize> {
+    env::var(env_var)
+        .unwrap_or_else(|_| default.to_string())
+        .split(',')
+        .filter_map(|s| s.trim().parse().ok())
+        .collect()
 }
 
-// Basic benchmark that always works
-fn simple_test(c: &mut Criterion) {
-    print_features_once();
-    c.bench_function("simple_test", |b| {
-        b.iter(|| {
-            let x = 2 + 2;
-            black_box(x);
+/// Get benchmark configuration from environment or defaults
+fn get_benchmark_config() -> (Vec<usize>, Vec<usize>) {
+    let signals = parse_counts("PETRA_BENCH_SIGNALS", "100,1000,10000");
+    let blocks = parse_counts("PETRA_BENCH_BLOCKS", "10,100,1000");
+    
+    // Ensure we have matching counts or use defaults
+    if signals.is_empty() || blocks.is_empty() || signals.len() != blocks.len() {
+        eprintln!("Warning: Invalid signal/block configuration, using defaults");
+        return (vec![100, 1000, 10000], vec![10, 100, 1000]);
+    }
+    
+    (signals, blocks)
+}
+
+fn create_benchmark_config(num_signals: usize, num_blocks: usize) -> Config {
+    let mut signals = Vec::new();
+    let mut blocks = Vec::new();
+
+    // Create signals with all required fields
+    for i in 0..num_signals {
+        signals.push(SignalConfig {
+            name: format!("signal_{}", i),
+            signal_type: "float".to_string(),
+            description: Some(format!("Test signal {}", i)),
+            initial: Some(serde_yaml::Value::from(0.0f64)),
+            metadata: HashMap::new(),
+            tags: vec![],
         });
-    });
-}
+    }
 
-// PETRA-specific benchmarks
-fn petra_value_benchmark(c: &mut Criterion) {
-    print_features_once();
-    use petra::Value;
+    // Create simple logic blocks (AND gates with 2 inputs)
+    for i in 0..num_blocks {
+        let mut inputs = HashMap::new();
+        inputs.insert("in1".to_string(), format!("signal_{}", i % num_signals));
+        inputs.insert(
+            "in2".to_string(),
+            format!("signal_{}", (i + 1) % num_signals),
+        );
 
-    c.bench_function("value_creation", |b| {
-        b.iter(|| {
-            let val = Value::Float(42.0);
-            black_box(val);
+        let mut outputs = HashMap::new();
+        outputs.insert(
+            "out".to_string(),
+            format!("signal_{}", (i + num_signals) % num_signals),
+        );
+
+        blocks.push(BlockConfig {
+            name: format!("block_{}", i),
+            block_type: "AND".to_string(),
+            description: Some(format!("Test AND block {}", i)),
+            inputs,
+            outputs,
+            params: HashMap::new(),
+            tags: vec![],
         });
-    });
+    }
+
+    Config {
+        signals,
+        blocks,
+        scan_time_ms: 50,
+        max_scan_jitter_ms: 50,
+        error_recovery: true,
+        // Feature-gated fields
+        #[cfg(feature = "mqtt")]
+        mqtt: None,
+        #[cfg(feature = "security")]
+        security: None,
+        #[cfg(feature = "history")]
+        history: None,
+        #[cfg(feature = "alarms")]
+        alarms: None,
+        #[cfg(feature = "web")]
+        web: None,
+        protocols: None,
+    }
 }
 
-fn signal_bus_benchmark(c: &mut Criterion) {
-    print_features_once();
-    use petra::{SignalBus, Value};
+fn benchmark_scan_performance(c: &mut Criterion) {
+    let mut group = c.benchmark_group("scan_performance");
+    group.measurement_time(Duration::from_secs(10));
+    group.warm_up_time(Duration::from_secs(3));
 
-    c.bench_function("signal_operations", |b| {
+    // Get configurable signal/block counts
+    let (signal_counts, block_counts) = get_benchmark_config();
+    
+    // Print configuration for debugging
+    eprintln!("Benchmark configuration:");
+    for (signals, blocks) in signal_counts.iter().zip(block_counts.iter()) {
+        eprintln!("  {} signals, {} blocks", signals, blocks);
+    }
+
+    // Create runtime for async operations
+    let rt = Runtime::new().unwrap();
+
+    // Test different scales using configured values
+    for (num_signals, num_blocks) in signal_counts.iter().zip(block_counts.iter()) {
+        let config = create_benchmark_config(*num_signals, *num_blocks);
+        let engine = Engine::new(config).expect("Failed to create engine");
+
+        group.throughput(Throughput::Elements(*num_blocks as u64));
+        group.bench_with_input(
+            BenchmarkId::new(
+                "signals_and_blocks",
+                format!("{}_signals_{}_blocks", num_signals, num_blocks),
+            ),
+            &(*num_signals, *num_blocks),
+            |b, _| {
+                b.iter(|| {
+                    // Use block_on since execute_scan_cycle is async
+                    rt.block_on(async {
+                        let _ = black_box(engine.execute_scan_cycle().await);
+                    });
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn benchmark_signal_bus_operations(c: &mut Criterion) {
+    let mut group = c.benchmark_group("signal_bus");
+
+    // Get largest signal count for stress testing
+    let (signal_counts, _) = get_benchmark_config();
+    let max_signals = signal_counts.iter().max().unwrap_or(&1000);
+
+    // Scale signal operations based on configuration
+    let test_signals = (*max_signals).min(10000); // Cap at 10k for reasonable test times
+
+    // Benchmark signal writes
+    group.bench_function(&format!("write_{}_signals", test_signals), |b| {
         let bus = SignalBus::new();
+
         b.iter(|| {
-            let _ = bus.set("test", Value::Float(1.0));
-            let val = bus.get("test").unwrap_or(Value::Float(0.0));
-            black_box(val);
+            for i in 0..test_signals {
+                let _ = bus.set(&format!("signal_{}", i), Value::Float(black_box(i as f64)));
+            }
+        });
+    });
+
+    // Benchmark signal reads
+    group.bench_function(&format!("read_{}_signals", test_signals), |b| {
+        let bus = SignalBus::new();
+
+        // Pre-populate signals
+        for i in 0..test_signals {
+            let _ = bus.set(&format!("signal_{}", i), Value::Float(i as f64));
+        }
+
+        b.iter(|| {
+            for i in 0..test_signals {
+                let _ = black_box(bus.get(&format!("signal_{}", i)));
+            }
+        });
+    });
+
+    // Benchmark atomic updates (scaled down for performance)
+    let update_signals = (test_signals / 10).max(100);
+    group.bench_function(&format!("atomic_update_{}_signals", update_signals), |b| {
+        let bus = SignalBus::new();
+
+        // Pre-populate
+        for i in 0..update_signals {
+            let _ = bus.set(&format!("counter_{}", i), Value::Integer(0));
+        }
+
+        b.iter(|| {
+            for i in 0..update_signals {
+                let _ = bus.update(&format!("counter_{}", i), |old| {
+                    match old {
+                        Some(Value::Integer(n)) => Value::Integer(n + 1),
+                        _ => Value::Integer(1),
+                    }
+                });
+            }
+        });
+    });
+
+    group.finish();
+}
+
+fn benchmark_block_execution(c: &mut Criterion) {
+    let mut group = c.benchmark_group("block_execution");
+
+    // Test different block counts
+    let (_, block_counts) = get_benchmark_config();
+    
+    for &num_blocks in &block_counts {
+        if num_blocks > 10000 {
+            continue; // Skip very large block counts for individual block tests
+        }
+
+        group.bench_function(&format!("execute_{}_blocks", num_blocks), |b| {
+            let config = create_benchmark_config(num_blocks * 2, num_blocks);
+            let engine = Engine::new(config).expect("Failed to create engine");
+            let rt = Runtime::new().unwrap();
+
+            b.iter(|| {
+                rt.block_on(async {
+                    let _ = black_box(engine.execute_scan_cycle().await);
+                });
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn benchmark_value_operations(c: &mut Criterion) {
+    let mut group = c.benchmark_group("value_operations");
+
+    // These don't scale with signal count, so keep them consistent
+    group.bench_function("value_creation", |b| {
+        b.iter(|| {
+            black_box(Value::Float(42.0));
+            black_box(Value::Integer(42));
+            black_box(Value::Bool(true));
+        });
+    });
+
+    group.bench_function("value_conversion", |b| {
+        let float_val = Value::Float(42.5);
+        let int_val = Value::Integer(42);
+        let bool_val = Value::Bool(true);
+
+        b.iter(|| {
+            let _ = black_box(float_val.as_f64());
+            let _ = black_box(int_val.as_i64());
+            let _ = black_box(bool_val.as_bool());
+        });
+    });
+
+    #[cfg(feature = "value-arithmetic")]
+    group.bench_function("value_arithmetic", |b| {
+        let val1 = Value::Float(10.0);
+        let val2 = Value::Float(20.0);
+
+        b.iter(|| {
+            let _ = black_box(val1.add(&val2));
+            let _ = black_box(val1.multiply(&val2));
+        });
+    });
+
+    group.finish();
+}
+
+// Add a simple test benchmark for quick validation
+fn benchmark_simple_test(c: &mut Criterion) {
+    c.bench_function("simple_test", |b| {
+        let bus = SignalBus::new();
+        let _ = bus.set("test_signal", Value::Float(42.0));
+        
+        b.iter(|| {
+            let _ = black_box(bus.get("test_signal"));
         });
     });
 }
 
-// Diagnostic benchmark for feature visibility
-fn diagnostic_benchmark(c: &mut Criterion) {
-    print_features_once();
+// Add a feature diagnostic benchmark
+fn benchmark_feature_diagnostic(c: &mut Criterion) {
     c.bench_function("feature_diagnostic", |b| {
         b.iter(|| {
+            // Test basic feature availability
+            #[cfg(feature = "enhanced-monitoring")]
+            let _enhanced = black_box(true);
+            
+            #[cfg(feature = "optimized")]
+            let _optimized = black_box(true);
+            
             #[cfg(feature = "extended-types")]
-            let extended = true;
-            #[cfg(not(feature = "extended-types"))]
-            let extended = false;
-
-            black_box(extended);
+            let _extended = black_box(true);
+            
+            // Basic operation that should always work
+            let _value = black_box(Value::Float(1.0));
         });
     });
 }
 
-// Configure benchmark groups depending on available features
-criterion_group!(
-    petra_benches,
-    simple_test,
-    petra_value_benchmark,
-    signal_bus_benchmark,
-    diagnostic_benchmark
-);
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(100)
+        .measurement_time(Duration::from_secs(5));
+    targets = 
+        benchmark_simple_test,
+        benchmark_feature_diagnostic,
+        benchmark_scan_performance, 
+        benchmark_signal_bus_operations, 
+        benchmark_block_execution, 
+        benchmark_value_operations
+}
 
-criterion_main!(petra_benches);
+criterion_main!(benches);

--- a/scripts/run-benchmark-preset.sh
+++ b/scripts/run-benchmark-preset.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# Simple benchmark runner with preset configurations
+
+set -e
+
+# Predefined configurations
+declare -A CONFIGS
+CONFIGS[quick]="SIGNALS=100,500 BLOCKS=10,50 FEATURES=--no-default-features"
+CONFIGS[standard]="SIGNALS=100,1000,5000 BLOCKS=10,100,500 FEATURES=--features optimized"
+CONFIGS[stress]="SIGNALS=1000,10000,50000 BLOCKS=100,1000,5000 FEATURES=--features enhanced-monitoring,optimized"
+CONFIGS[memory]="SIGNALS=10000,50000,100000 BLOCKS=1000,5000,10000 FEATURES=--features optimized,realtime"
+CONFIGS[edge]="SIGNALS=50,100,500 BLOCKS=5,10,50 FEATURES=--no-default-features"
+
+print_usage() {
+    cat << EOF
+Usage: $0 [PRESET|OPTIONS]
+
+Presets:
+    quick       Fast test (< 30s): 100-500 signals, 10-50 blocks
+    standard    Balanced test (2-3m): 100-5k signals, 10-500 blocks  
+    stress      Heavy test (10+ m): 1k-50k signals, 100-5k blocks
+    memory      Memory test: 10k-100k signals, 1k-10k blocks
+    edge        Edge device: 50-500 signals, 5-50 blocks
+
+Custom Options:
+    --signals COUNT1,COUNT2,...    Custom signal counts
+    --blocks COUNT1,COUNT2,...     Custom block counts  
+    --features FLAGS               Custom feature flags
+    --baseline NAME                Save baseline
+    --compare NAME                 Compare with baseline
+
+Examples:
+    $0 quick                       # Run quick preset
+    $0 --signals 1000 --blocks 100 # Custom single test
+    $0 stress --baseline v1.0      # Stress test with baseline
+    $0 --compare v1.0              # Compare with saved baseline
+
+EOF
+}
+
+PRESET=""
+CUSTOM_SIGNALS=""
+CUSTOM_BLOCKS=""
+CUSTOM_FEATURES=""
+BASELINE=""
+COMPARE=""
+
+if [[ $# -eq 0 ]]; then
+    print_usage
+    exit 1
+fi
+
+if [[ -n "${CONFIGS[$1]}" ]]; then
+    PRESET="$1"
+    shift
+fi
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --signals)
+            CUSTOM_SIGNALS="$2"
+            shift 2
+            ;;
+        --blocks)
+            CUSTOM_BLOCKS="$2"
+            shift 2
+            ;;
+        --features)
+            CUSTOM_FEATURES="$2"
+            shift 2
+            ;;
+        --baseline)
+            BASELINE="$2"
+            shift 2
+            ;;
+        --compare)
+            COMPARE="$2"
+            shift 2
+            ;;
+        --help)
+            print_usage
+            exit 0
+            ;;
+        *)
+            if [[ -n "${CONFIGS[$1]}" ]]; then
+                PRESET="$1"
+                shift
+            else
+                echo "Unknown option: $1"
+                print_usage
+                exit 1
+            fi
+            ;;
+    esac
+done
+
+if [[ -n "$PRESET" ]]; then
+    echo "🎯 Using preset: $PRESET"
+    eval "${CONFIGS[$PRESET]}"
+else
+    echo "🔧 Using custom configuration"
+    SIGNALS="$CUSTOM_SIGNALS"
+    BLOCKS="$CUSTOM_BLOCKS"
+    FEATURES="$CUSTOM_FEATURES"
+fi
+
+[[ -n "$CUSTOM_SIGNALS" ]] && SIGNALS="$CUSTOM_SIGNALS"
+[[ -n "$CUSTOM_BLOCKS" ]] && BLOCKS="$CUSTOM_BLOCKS"
+[[ -n "$CUSTOM_FEATURES" ]] && FEATURES="$CUSTOM_FEATURES"
+
+if [[ -z "$SIGNALS" || -z "$BLOCKS" ]]; then
+    echo "❌ Error: Signals and blocks must be specified"
+    print_usage
+    exit 1
+fi
+
+export PETRA_BENCH_SIGNALS="$SIGNALS"
+export PETRA_BENCH_BLOCKS="$BLOCKS"
+
+CMD="cargo bench $FEATURES --bench engine_performance"
+
+if [[ -n "$BASELINE" ]]; then
+    CMD="$CMD -- --save-baseline $BASELINE"
+elif [[ -n "$COMPARE" ]]; then
+    CMD="$CMD -- --baseline $COMPARE"
+fi
+
+echo "📊 Benchmark Configuration"
+echo "=========================="
+echo "Signals: $SIGNALS"
+echo "Blocks: $BLOCKS"
+echo "Features: ${FEATURES:-"(default)"}"
+[[ -n "$BASELINE" ]] && echo "Baseline: $BASELINE"
+[[ -n "$COMPARE" ]] && echo "Compare: $COMPARE"
+echo ""
+
+IFS=',' read -ra SIGNAL_ARRAY <<< "$SIGNALS"
+count=${#SIGNAL_ARRAY[@]}
+case $count in
+    1|2) echo "⏱️  Estimated runtime: < 1 minute" ;;
+    3|4) echo "⏱️  Estimated runtime: 2-3 minutes" ;;
+    *) echo "⏱️  Estimated runtime: 5+ minutes" ;;
+esac
+
+if [[ ${SIGNALS} == *"50000"* ]] || [[ ${SIGNALS} == *"100000"* ]]; then
+    echo "⚠️  Warning: This will run a stress test with large signal counts"
+    read -p "Continue? (y/N): " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Cancelled"
+        exit 0
+    fi
+fi
+
+echo "🚀 Running: $CMD"
+echo ""
+eval $CMD
+
+echo ""
+echo "✅ Benchmark complete!"
+echo "📊 View detailed reports: target/criterion/report/index.html"

--- a/scripts/run-benchmarks-enhanced.sh
+++ b/scripts/run-benchmarks-enhanced.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+# Enhanced benchmark runner with configurable signal counts
+
+set -e
+
+# Default values
+DEFAULT_SIGNALS="100,1000,10000"
+DEFAULT_BLOCKS="10,100,1000"
+DEFAULT_FEATURES="--no-default-features"
+DEFAULT_OUTPUT_DIR="bench_results"
+
+# Parse command line arguments
+SIGNALS="${SIGNALS:-$DEFAULT_SIGNALS}"
+BLOCKS="${BLOCKS:-$DEFAULT_BLOCKS}"
+FEATURES="${FEATURES:-$DEFAULT_FEATURES}"
+OUTPUT_DIR="${OUTPUT_DIR:-$DEFAULT_OUTPUT_DIR}"
+BASELINE=""
+COMPARE_BASELINE=""
+
+print_usage() {
+    cat << EOF
+Usage: $0 [OPTIONS]
+
+Options:
+    --signals COUNTS        Comma-separated signal counts (default: $DEFAULT_SIGNALS)
+    --blocks COUNTS         Comma-separated block counts (default: $DEFAULT_BLOCKS)
+    --features FLAGS        Cargo feature flags (default: $DEFAULT_FEATURES)
+    --output-dir DIR        Output directory (default: $DEFAULT_OUTPUT_DIR)
+    --baseline NAME         Save baseline with name
+    --compare BASELINE      Compare with existing baseline
+    --help                  Show this help
+
+Environment Variables:
+    SIGNALS                 Override signal counts
+    BLOCKS                  Override block counts
+    FEATURES                Override feature flags
+    OUTPUT_DIR              Override output directory
+
+Examples:
+    # Quick test with small signal counts
+    $0 --signals "100,500" --blocks "10,50"
+    
+    # Stress test with large signal counts
+    $0 --signals "10000,50000,100000" --blocks "1000,5000,10000"
+    
+    # Test with specific features
+    $0 --features "--features enhanced-monitoring,optimized"
+    
+    # Save a baseline for comparison
+    $0 --baseline "v1.0.0" --signals "1000,10000"
+    
+    # Compare with previous baseline
+    $0 --compare "v1.0.0" --signals "1000,10000"
+
+EOF
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --signals)
+            SIGNALS="$2"
+            shift 2
+            ;;
+        --blocks)
+            BLOCKS="$2"
+            shift 2
+            ;;
+        --features)
+            FEATURES="$2"
+            shift 2
+            ;;
+        --output-dir)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --baseline)
+            BASELINE="$2"
+            shift 2
+            ;;
+        --compare)
+            COMPARE_BASELINE="$2"
+            shift 2
+            ;;
+        --help)
+            print_usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            print_usage
+            exit 1
+            ;;
+    esac
+done
+
+# Create output directory
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+RESULTS_DIR="$OUTPUT_DIR/$TIMESTAMP"
+mkdir -p "$RESULTS_DIR"
+
+# Convert comma-separated values to arrays
+IFS=',' read -ra SIGNAL_COUNTS <<< "$SIGNALS"
+IFS=',' read -ra BLOCK_COUNTS <<< "$BLOCKS"
+
+echo "🚀 Running PETRA benchmarks"
+echo "=========================="
+echo "Signal counts: ${SIGNAL_COUNTS[*]}"
+echo "Block counts: ${BLOCK_COUNTS[*]}"
+echo "Features: $FEATURES"
+echo "Output: $RESULTS_DIR"
+echo ""
+
+# Set environment variables for the benchmark
+export PETRA_BENCH_SIGNALS="$SIGNALS"
+export PETRA_BENCH_BLOCKS="$BLOCKS"
+
+# Build benchmark arguments
+BENCH_ARGS="--bench engine_performance"
+if [[ -n "$BASELINE" ]]; then
+    BENCH_ARGS="$BENCH_ARGS -- --save-baseline $BASELINE"
+elif [[ -n "$COMPARE_BASELINE" ]]; then
+    BENCH_ARGS="$BENCH_ARGS -- --baseline $COMPARE_BASELINE"
+fi
+
+# Run the benchmark
+echo "📊 Running benchmark with: cargo bench $FEATURES $BENCH_ARGS"
+cargo bench $FEATURES $BENCH_ARGS 2>&1 | tee "$RESULTS_DIR/output.txt"
+
+# Run feature-specific benchmarks if requested
+if [[ "$FEATURES" != *"--no-default-features"* ]]; then
+    echo ""
+    echo "📊 Running minimal feature benchmark for comparison..."
+    cargo bench --no-default-features --bench engine_performance 2>&1 | tee "$RESULTS_DIR/minimal.txt"
+fi
+
+# Generate summary report
+cat > "$RESULTS_DIR/summary.md" << EOF
+# Benchmark Results - $TIMESTAMP
+
+## Configuration
+- Signal counts: ${SIGNAL_COUNTS[*]}
+- Block counts: ${BLOCK_COUNTS[*]}
+- Features: $FEATURES
+- Rust version: $(rustc --version)
+- Platform: $(uname -a)
+
+## Results Summary
+```
+$(grep -E "time:|throughput:|faster|slower" "$RESULTS_DIR/output.txt" | head -20)
+```
+
+## Performance Analysis
+$(
+if [[ -n "$COMPARE_BASELINE" ]]; then
+    echo "### Comparison with $COMPARE_BASELINE"
+    grep -E "change:|Performance" "$RESULTS_DIR/output.txt" || echo "No significant changes detected"
+fi
+)
+
+## Raw Output
+See `output.txt` for complete results.
+
+## Criterion Reports
+Open `target/criterion/report/index.html` for detailed HTML reports.
+EOF
+
+# Performance analysis
+echo ""
+echo "🎯 Performance Analysis"
+echo "======================"
+
+# Extract key metrics
+if grep -q "scan_performance" "$RESULTS_DIR/output.txt"; then
+    echo "✅ Scan performance results found"
+    grep -A5 -B2 "scan_performance" "$RESULTS_DIR/output.txt" | head -20
+else
+    echo "⚠️  No scan performance results found"
+fi
+
+# Check for warnings or errors
+if grep -qi "error\|failed\|panic" "$RESULTS_DIR/output.txt"; then
+    echo "❌ Errors detected in benchmark run"
+    grep -i "error\|failed\|panic" "$RESULTS_DIR/output.txt"
+fi
+
+echo ""
+echo "✅ Benchmark complete!"
+echo "📁 Results saved to: $RESULTS_DIR/"
+echo "📊 HTML report: target/criterion/report/index.html"
+echo "📋 Summary: $RESULTS_DIR/summary.md"

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Run benchmarks and generate reports
-# Fixed version that avoids dependencies requiring libclang/bindgen
+# Updated to support configurable signal counts
 
 set -e
 
@@ -8,248 +8,43 @@ TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 RESULTS_DIR="bench_results/$TIMESTAMP"
 mkdir -p "$RESULTS_DIR"
 
-echo "Running benchmarks..."
-echo "Note: Avoiding features that require libclang (zstd, rocksdb, cranelift)"
+# Default configuration (can be overridden by environment variables)
+export PETRA_BENCH_SIGNALS="${PETRA_BENCH_SIGNALS:-100,1000,10000}"
+export PETRA_BENCH_BLOCKS="${PETRA_BENCH_BLOCKS:-10,100,1000}"
 
-# Function to check if feature exists
-check_feature_exists() {
-    local feature=$1
-    if grep -q "^$feature = " Cargo.toml; then
-        return 0
-    else
-        return 1
-    fi
-}
+echo "🏃 Running benchmarks..."
+echo "Configuration: ${PETRA_BENCH_SIGNALS} signals, ${PETRA_BENCH_BLOCKS} blocks"
 
-# Define safe feature sets that don't require libclang
-SAFE_CORE_FEATURES="standard-monitoring,enhanced-monitoring,optimized,metrics,realtime"
-SAFE_PROTOCOL_FEATURES="mqtt"
-SAFE_BASIC_FEATURES="extended-types,validation,regex-validation"
-SAFE_WEB_FEATURES="web,health,alarms,email"
+# Run standard benchmarks
+cargo bench --all-features -- --save-baseline "$TIMESTAMP" | tee "$RESULTS_DIR/output.txt"
 
-# Build safe feature combinations
-MINIMAL_SAFE_FEATURES="standard-monitoring"
-STANDARD_SAFE_FEATURES="$SAFE_CORE_FEATURES,$SAFE_PROTOCOL_FEATURES,$SAFE_BASIC_FEATURES"
-ENHANCED_SAFE_FEATURES="$STANDARD_SAFE_FEATURES,$SAFE_WEB_FEATURES"
+echo "Running minimal features..."
+cargo bench --no-default-features --bench engine_performance | tee "$RESULTS_DIR/minimal.txt"
 
-# Function to run benchmark with error handling
-run_benchmark() {
-    local name=$1
-    local features=$2
-    local output_file=$3
-    
-    echo "Running $name features..."
-    echo "Benchmark features:" | tee "$output_file"
-    
-    # Show which features are enabled
-    if [[ "$features" == "--no-default-features" ]]; then
-        echo "Mode: Minimal (no default features)" | tee -a "$output_file"
-        echo "Extended types: false" | tee -a "$output_file"
-        echo "Enhanced monitoring: false" | tee -a "$output_file"
-    else
-        echo "Mode: $name" | tee -a "$output_file"
-        echo "Features: $features" | tee -a "$output_file"
-        echo "Extended types: $(echo "$features" | grep -q 'extended-types' && echo true || echo false)" | tee -a "$output_file"
-        echo "Enhanced monitoring: $(echo "$features" | grep -q 'enhanced-monitoring' && echo true || echo false)" | tee -a "$output_file"
-    fi
-    
-    # Run the benchmark
-    if [[ "$features" == "--no-default-features" ]]; then
-        echo "Running: cargo bench --no-default-features --bench engine_performance" | tee -a "$output_file"
-        cargo bench --no-default-features --bench engine_performance 2>&1 | tee -a "$output_file"
-    else
-        echo "Running: cargo bench --no-default-features --features \"$features\" --bench engine_performance" | tee -a "$output_file"
-        cargo bench --no-default-features --features "$features" --bench engine_performance 2>&1 | tee -a "$output_file"
-    fi
-    
-    local exit_code=$?
-    if [ $exit_code -ne 0 ]; then
-        echo "Benchmark failed with exit code: $exit_code" | tee -a "$output_file"
-        return $exit_code
-    else
-        echo "Benchmark completed successfully" | tee -a "$output_file"
-        return 0
-    fi
-}
+echo "Running enhanced features..."
+cargo bench --features enhanced --bench engine_performance | tee "$RESULTS_DIR/enhanced.txt"
 
-# Start with minimal benchmark (baseline)
-echo "=== Running Minimal Benchmark (Baseline) ==="
-if run_benchmark "minimal" "--no-default-features" "$RESULTS_DIR/minimal.txt"; then
-    echo "Minimal benchmark completed"
-else
-    echo "Minimal benchmark failed - this indicates a fundamental build issue"
+if [ -f "target/criterion/scan_performance/signals_and_blocks/1000-100/base/estimates.json" ]; then
+    echo "📊 Comparing with baseline..."
+    cargo bench -- --baseline base | tee "$RESULTS_DIR/comparison.txt"
 fi
 
-echo ""
-echo "=== Running Safe Feature Combinations ==="
-
-# Run benchmarks with progressively more features (but avoiding bindgen deps)
-if run_benchmark "basic-monitoring" "$MINIMAL_SAFE_FEATURES" "$RESULTS_DIR/basic.txt"; then
-    echo "Basic monitoring benchmark completed"
-else
-    echo "Basic monitoring benchmark failed"
-fi
-
-if run_benchmark "standard-safe" "$STANDARD_SAFE_FEATURES" "$RESULTS_DIR/standard-safe.txt"; then
-    echo "Standard safe features benchmark completed"
-else
-    echo "Standard safe features benchmark failed"
-fi
-
-if run_benchmark "enhanced-safe" "$ENHANCED_SAFE_FEATURES" "$RESULTS_DIR/enhanced-safe.txt"; then
-    echo "Enhanced safe features benchmark completed"
-else
-    echo "Enhanced safe features benchmark failed"
-fi
-
-# Test individual feature bundles if they exist (and are safe)
-echo ""
-echo "=== Testing Feature Bundles ==="
-
-if check_feature_exists "edge"; then
-    if run_benchmark "edge-bundle" "edge" "$RESULTS_DIR/edge.txt"; then
-        echo "Edge bundle benchmark completed"
-    else
-        echo "Edge bundle benchmark failed"
-    fi
-fi
-
-# Test production bundle but exclude problematic dependencies
-if check_feature_exists "production"; then
-    echo "Checking if production bundle requires bindgen dependencies..."
-    if cargo check --no-default-features --features "production" 2>&1 | grep -q "clang-sys\|bindgen"; then
-        echo "Production bundle requires libclang - skipping"
-        echo "Production bundle requires libclang dependencies - skipped" > "$RESULTS_DIR/production-skipped.txt"
-    else
-        if run_benchmark "production" "production" "$RESULTS_DIR/production.txt"; then
-            echo "Production bundle benchmark completed"
-        else
-            echo "Production bundle benchmark failed"
-        fi
-    fi
-fi
-
-# Save baseline for future comparison
-echo ""
-echo "Saving baseline for future comparisons..."
-if [ -f "target/criterion/*/report/index.html" ]; then
-    cargo bench --no-default-features --features "$MINIMAL_SAFE_FEATURES" -- --save-baseline "safe-baseline-$TIMESTAMP" 2>&1 | tee "$RESULTS_DIR/baseline.txt"
-fi
-
-# Generate comprehensive summary
-cat > "$RESULTS_DIR/summary.md" << EOF
-# PETRA Benchmark Results - $TIMESTAMP
+cat > "$RESULTS_DIR/summary.md" << EOM
+# Benchmark Results - $TIMESTAMP
 
 ## Configuration
-- **Rust version**: \$(rustc --version)
-- **Cargo version**: \$(cargo --version)
-- **Platform**: \$(uname -a)
-- **Benchmark Strategy**: Avoiding bindgen dependencies (zstd, rocksdb, cranelift)
+- Signal configuration: ${PETRA_BENCH_SIGNALS}
+- Block configuration: ${PETRA_BENCH_BLOCKS}
+- Rust version: $(rustc --version)
+- Features: all
+- Platform: $(uname -a)
 
-## Feature Sets Tested
+## Key Metrics
+$(grep -E "time:|throughput:" "$RESULTS_DIR/output.txt" | head -20)
 
-### Minimal (Baseline)
-- **Features**: None (--no-default-features)
-- **Purpose**: Absolute baseline performance
-- **Result**: \([ -f "$RESULTS_DIR/minimal.txt" ] && grep -q "completed successfully" "$RESULTS_DIR/minimal.txt" && echo "Success" || echo "Failed"\)
+## Comparison with Baseline
+$(grep -E "change:|Performance" "$RESULTS_DIR/comparison.txt" 2>/dev/null || echo "No baseline available")
+EOM
 
-### Basic Monitoring
-- **Features**: \`$MINIMAL_SAFE_FEATURES\`
-- **Purpose**: Basic monitoring overhead measurement
-- **Result**: \([ -f "$RESULTS_DIR/basic.txt" ] && grep -q "completed successfully" "$RESULTS_DIR/basic.txt" && echo "Success" || echo "Failed"\)
-
-### Standard Safe Features
-- **Features**: \`$STANDARD_SAFE_FEATURES\`
-- **Purpose**: Standard deployment without heavy dependencies
-- **Result**: \([ -f "$RESULTS_DIR/standard-safe.txt" ] && grep -q "completed successfully" "$RESULTS_DIR/standard-safe.txt" && echo "Success" || echo "Failed"\)
-
-### Enhanced Safe Features
-- **Features**: \`$ENHANCED_SAFE_FEATURES\`
-- **Purpose**: Full-featured deployment without bindgen dependencies
-- **Result**: \([ -f "$RESULTS_DIR/enhanced-safe.txt" ] && grep -q "completed successfully" "$RESULTS_DIR/enhanced-safe.txt" && echo "Success" || echo "Failed"\)
-
-## Performance Metrics
-
-### Key Timing Results
-\$(if [ -f "$RESULTS_DIR/minimal.txt" ]; then
-    echo "**Minimal Features:**"
-    grep -E "time:|simple_test|value_creation|signal_operations|feature_diagnostic" "$RESULTS_DIR/minimal.txt" | head -10 | sed 's/^/- /'
-fi)
-
-\$(if [ -f "$RESULTS_DIR/enhanced-safe.txt" ]; then
-    echo ""
-    echo "**Enhanced Safe Features:**"
-    grep -E "time:|simple_test|value_creation|signal_operations|feature_diagnostic" "$RESULTS_DIR/enhanced-safe.txt" | head -10 | sed 's/^/- /'
-fi)
-
-## Dependencies Avoided
-
-The following dependencies require libclang/bindgen and were excluded:
-- **zstd** (compression) - requires zstd-sys with bindgen
-- **rocksdb** (database) - requires librocksdb-sys with bindgen  
-- **cranelift** family (JIT compilation) - requires LLVM bindings
-- **advanced-storage** bundle - includes rocksdb
-- **compression** features - includes zstd
-- **jit-compilation** features - includes cranelift
-
-## Recommendations
-
-### For CI/CD Pipelines
-1. Use **minimal** and **standard-safe** feature sets for regular benchmarks
-2. Test **enhanced-safe** features for comprehensive performance analysis
-3. Set up separate environment with libclang for full feature testing
-
-### For Development
-- Use \`cargo build --no-default-features --features "$STANDARD_SAFE_FEATURES"\` for fast builds
-- Install libclang dependencies only when testing storage/compression features
-
-### For Production Deployment
-- **Edge devices**: Use minimal or basic monitoring features
-- **Standard servers**: Use standard-safe feature set
-- **Enterprise**: Install libclang and use full feature set including storage
-
-## Files Generated
-\$(ls -la "$RESULTS_DIR"/*.txt 2>/dev/null | awk '{print "- " $9}' || echo "- No benchmark files generated")
-
-EOF
-
-echo ""
-echo "Results saved to $RESULTS_DIR/"
-echo "View detailed reports at target/criterion/report/index.html"
-echo "View summary at $RESULTS_DIR/summary.md"
-
-# Display quick summary
-echo ""
-echo "Quick Summary:"
-echo "=============="
-
-declare -A results
-if [ -f "$RESULTS_DIR/minimal.txt" ] && grep -q "completed successfully" "$RESULTS_DIR/minimal.txt"; then
-    results["Minimal"]="Success"
-else
-    results["Minimal"]="Failed"
-fi
-
-if [ -f "$RESULTS_DIR/standard-safe.txt" ] && grep -q "completed successfully" "$RESULTS_DIR/standard-safe.txt"; then
-    results["Standard"]="Success"
-else
-    results["Standard"]="Failed"
-fi
-
-if [ -f "$RESULTS_DIR/enhanced-safe.txt" ] && grep -q "completed successfully" "$RESULTS_DIR/enhanced-safe.txt"; then
-    results["Enhanced"]="Success"
-else
-    results["Enhanced"]="Failed"
-fi
-
-for config in "${!results[@]}"; do
-    echo "$config: ${results[$config]}"
-done
-
-echo ""
-echo "To run benchmarks with ALL features (requires libclang):"
-echo "   sudo apt install -y llvm-dev libclang-dev"
-echo "   export LIBCLANG_PATH=/usr/lib/llvm-14/lib"
-echo "   cargo bench --all-features"
-echo ""
-echo "Open target/criterion/report/index.html for detailed analysis"
+echo "✅ Results saved to $RESULTS_DIR/"
+echo "📈 View detailed reports at target/criterion/report/index.html"


### PR DESCRIPTION
## Summary
- rewrite benchmark implementation with configurable signal counts
- add enhanced benchmark runner scripts
- add preset-based benchmark runner
- update run-benchmarks script to support new configuration
- update benchmark docs
- tweak dev dependencies for criterion/tokio

## Testing
- `cargo bench --bench engine_performance --no-run` *(fails: could not compile `petra`)*
- `PETRA_BENCH_SIGNALS="100" PETRA_BENCH_BLOCKS="10" cargo bench --bench engine_performance --no-run` *(fails: could not compile `petra`)*
- `./scripts/run-benchmark-preset.sh quick` *(fails: could not compile `petra`)*
- `./scripts/run-benchmarks-enhanced.sh --signals "100,1000" --blocks "10,100" --output-dir "test_results"` *(fails: could not compile `petra`)*


------
https://chatgpt.com/codex/tasks/task_e_6868cb4572ec832c80f0ade381309dc7