### PR TITLE
Add config linting and feature utilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -561,6 +561,7 @@ required-features = ["cli"]
 [[bench]]
 name = "engine_performance"
 harness = false
+required-features = ["standard-monitoring"]
 
 [[bench]]
 name = "simple_working"

--- a/benches/simple_working.rs
+++ b/benches/simple_working.rs
@@ -1,13 +1,12 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-fn basic_benchmark(c: &mut Criterion) {
-    c.bench_function("basic_test", |b| {
+fn simple_benchmark(c: &mut Criterion) {
+    c.bench_function("simple_test", |b| {
         b.iter(|| {
-            let x = 1 + 1;
-            black_box(x);
+            black_box(1 + 1)
         });
     });
 }
 
-criterion_group!(benches, basic_benchmark);
+criterion_group!(benches, simple_benchmark);
 criterion_main!(benches);

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -1,0 +1,9 @@
+pub fn build_info_string() -> String {
+    let info = crate::build_info();
+    format!(
+        "version: {}, commit: {} built {}",
+        info.version,
+        info.git_commit.unwrap_or("unknown"),
+        info.build_timestamp
+    )
+}

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -561,6 +561,11 @@ pub fn is_enabled(feature: &str) -> bool {
     RuntimeFeatures::detect().is_enabled(feature)
 }
 
+/// Alias for init (backward compatibility)
+pub fn validate_feature_dependencies() -> Result<(), Vec<String>> {
+    init()
+}
+
 // Re-export for convenience
 pub use RuntimeFeatures as Features;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,7 @@ pub mod engine;
 /// Runtime feature detection, validation of feature dependencies,
 /// and feature reporting for debugging and diagnostics.
 pub mod features;
+pub mod build_info;
 
 // ============================================================================
 // BLOCK SYSTEM (High Priority)
@@ -362,7 +363,7 @@ pub mod gui;
 pub use error::{PlcError, Result};
 pub use value::{Value, ValueType};
 pub use signal::SignalBus;
-pub use config::{Config, BlockConfig, SignalConfig};
+pub use config::{Config, BlockConfig, SignalConfig, LintSeverity, LintResult};
 pub use engine::EngineConfig;
 pub use engine::Engine;
 pub use features::{Features, RuntimeFeatures};


### PR DESCRIPTION
## Summary
- introduce `LintSeverity`, `LintResult`, `ConfigTemplate`, and `ConfigFormat`
- implement configuration linting helpers
- extend feature API with validation alias
- expose new types in public exports
- add simple build info helper module
- adjust CLI and benchmarking setup
- create simple benchmark example

## Testing
- `cargo build`
- `cargo bench --bench simple_working` *(fails: benchmark cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_686957310e98832c83b6975925e32178