### PR TITLE
Fix docs and benchmark script

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2859,23 +2859,61 @@ impl Validatable for OpcuaConfig {
 // CONFIGURATION TEMPLATES
 // ============================================================================
 
-/// Pre-defined configuration templates
+/// Configuration template types for different deployment scenarios
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[derive(Debug, Clone, Copy)]
 pub enum ConfigTemplate {
+    /// Basic configuration template for simple deployments
+    ///
+    /// Includes minimal features and basic signal/block definitions.
+    /// Suitable for development and testing environments.
     Basic,
+
+    /// Industrial automation configuration template
+    ///
+    /// Includes industrial protocols (S7, Modbus, OPC-UA), alarms,
+    /// and enhanced monitoring for manufacturing environments.
     Industrial,
+
+    /// IoT edge device configuration template
+    ///
+    /// Optimized for edge devices with MQTT connectivity and
+    /// minimal resource usage. Ideal for sensor networks.
     Iot,
+
+    /// Enterprise configuration template
+    ///
+    /// Full-featured template with security, comprehensive storage,
+    /// advanced monitoring, and all protocol support.
     Enterprise,
+
+    /// Development configuration template
+    ///
+    /// Includes debugging features, test signals, and development
+    /// tools for feature development and testing.
     Development,
 }
 
-/// Configuration file formats
+/// Configuration file format types
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[derive(Debug, Clone, Copy)]
 pub enum ConfigFormat {
+    /// YAML format (default and recommended)
+    ///
+    /// Human-readable format with comments and good structure.
+    /// Default format for PETRA configurations.
     Yaml,
+
+    /// JSON format for API integration
+    ///
+    /// Structured format suitable for programmatic generation
+    /// and API-based configuration management.
     Json,
+
+    /// TOML format for simple configurations
+    ///
+    /// Alternative format for users preferring TOML syntax.
+    /// Not all features may be supported.
     Toml,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,6 @@ use petra::{
 use petra::build_info;
 use std::path::PathBuf;
 use std::process;
-use std::time::Duration;
 use tokio::signal;
 use tracing::{info, error, debug, warn, Level};
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
@@ -1264,7 +1263,7 @@ async fn migrate_config_version(
 async fn show_config_schema(
     #[cfg(feature = "schema-validation")]
     json_format: bool,
-    output: Option<PathBuf>,
+    _output: Option<PathBuf>,
 ) -> Result<()> {
     #[cfg(feature = "schema-validation")]
     {
@@ -1274,7 +1273,7 @@ async fn show_config_schema(
             Config::yaml_schema()?
         };
         
-        if let Some(output_path) = output {
+        if let Some(output_path) = _output {
             std::fs::write(&output_path, &schema).map_err(|e|
                 PlcError::Config(format!("Failed to write schema: {}", e))
             )?;


### PR DESCRIPTION
## Summary
- document `ConfigTemplate` and `ConfigFormat`
- remove unused import and parameter in `main.rs`
- clean up benchmark script with error handling and default features

## Testing
- `cargo check 2>&1 | grep "missing documentation"`
- `cargo check 2>&1 | grep unused`
- `./scripts/run-benchmarks-enhanced.sh --signals "100" --blocks "10" --features "--features standard-monitoring"` *(fails: build process lengthy)*
- `cargo clippy --all-features` *(fails: couldn't find libclang)*
- `cargo test --features standard-monitoring` *(fails: compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68697667499c832cb65cddbb1a962f01