### PR TITLE
Fix compile warnings and feature checks

### DIFF
--- a/src/alarms.rs
+++ b/src/alarms.rs
@@ -387,7 +387,7 @@ impl AlarmManager {
                 alarm.last_update = Utc::now();
             }
 
-            let mut should_activate =
+            let should_activate =
                 Self::evaluate_condition(&bus, &alarm.config.condition, &signal_value)?;
 
             #[cfg(feature = "alarm-hysteresis")]
@@ -463,7 +463,7 @@ impl AlarmManager {
         Ok(())
     }
 
-    fn evaluate_condition(bus: &SignalBus, condition: &AlarmCondition, value: &Value) -> Result<bool> {
+    fn evaluate_condition(_bus: &SignalBus, condition: &AlarmCondition, value: &Value) -> Result<bool> {
         Ok(match condition {
             AlarmCondition::High { threshold } => value.as_float().unwrap_or(0.0) > *threshold,
             AlarmCondition::Low { threshold } => value.as_float().unwrap_or(0.0) < *threshold,
@@ -489,7 +489,7 @@ impl AlarmManager {
                 reference_signal,
                 max_deviation,
             } => {
-                if let Some(ref_value) = bus.get(reference_signal) {
+                if let Some(ref_value) = _bus.get(reference_signal) {
                     let v = value.as_float().unwrap_or(0.0);
                     let ref_v = ref_value.as_float().unwrap_or(0.0);
                     (v - ref_v).abs() > *max_deviation

--- a/src/config.rs
+++ b/src/config.rs
@@ -797,7 +797,7 @@ impl Default for MqttConfig {
 #[cfg(feature = "mqtt")]
 impl MqttConfig {
     /// Validate MQTT configuration
-    pub fn validate(&self) -> Result<(), PlcError> {
+    pub fn validate(&self) -> Result<()> {
         if self.host.is_empty() {
             return Err(PlcError::Config("MQTT host cannot be empty".to_string()));
         }
@@ -847,7 +847,13 @@ impl MqttConfig {
         }
 
         if self.use_tls {
-            options.set_transport(rumqttc::Transport::Tls(rumqttc::TlsConfiguration::Simple));
+            options.set_transport(rumqttc::Transport::Tls(
+                rumqttc::TlsConfiguration::Simple {
+                    ca: Vec::new(),
+                    alpn: None,
+                    client_auth: None,
+                },
+            ));
         }
 
         options
@@ -2057,7 +2063,7 @@ impl Config {
         
         // Check other feature compatibility
         #[cfg(feature = "mqtt")]
-        if self.mqtt.is_some() && !features.has_mqtt() {
+        if self.mqtt.is_some() && !features.is_enabled("mqtt") {
             return Err(PlcError::Config(
                 "Configuration uses MQTT but mqtt feature is not enabled".to_string()
             ));
@@ -2078,7 +2084,7 @@ impl Config {
         }
         
         #[cfg(feature = "alarms")]
-        if self.alarms.is_some() && !features.has_alarms() {
+        if self.alarms.is_some() && !features.is_enabled("alarms") {
             return Err(PlcError::Config(
                 "Configuration uses alarms but alarms feature is not enabled".to_string()
             ));


### PR DESCRIPTION
## Summary
- fix MQTT config validation return type
- update TLS configuration setup in `connection_options`
- validate features via `is_enabled` calls
- remove unused mut and bus variable warnings in alarms

## Testing
- `cargo check`
- `cargo test` *(fails: could not compile `petra` due to 33 previous errors)*

------
https://chatgpt.com/codex/tasks/task_e_68698f8fc904832c83bddc6c3855e497