### PR TITLE
Fix KeyType string conversion

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1559,7 +1559,14 @@ async fn start_health_server(port: u16, bind: String, check_interval: u64) -> Re
 async fn handle_security_command(cmd: SecurityCommands) -> Result<()> {
     match cmd {
         SecurityCommands::KeyGen { key_type, output } => {
-            petra::security::generate_key(&key_type.to_string(), &output).await?;
+            let key_type_str = match key_type {
+                KeyType::Rsa => "rsa",
+                KeyType::Ed25519 => "ed25519",
+                KeyType::Aes => "aes",
+                #[cfg(feature = "jwt-auth")]
+                KeyType::Jwt => "jwt",
+            };
+            petra::security::generate_key(key_type_str, &output).await?;
             println!("{} Generated {} key: {}", 
                 "SUCCESS".green().bold(),
                 format!("{:?}", key_type).to_lowercase(), 


### PR DESCRIPTION
## Summary
- fix KeyType enum string conversion in `handle_security_command`

## Testing
- `cargo test --lib` *(fails: could not compile `petra` due to previous errors)*

------
https://chatgpt.com/codex/tasks/task_e_686b20f60954832cafca15bda2476c3b