### PR TITLE
Remove duplicate variable in WaterPlantDemo

### DIFF
--- a/petra-designer/src/components/hmi/WaterPlantDemo.tsx
+++ b/petra-designer/src/components/hmi/WaterPlantDemo.tsx
@@ -257,7 +257,6 @@ export default function WaterPlantDemo() {
         // Round-robin lead/lag pump control
         let currentLeadPump = prev.currentLeadPump
         const leadPump = prev.boosterPumps.find(p => p.pumpNumber === currentLeadPump)
-        const runningPumps = prev.boosterPumps.filter(p => p.running)
         
         let updatedPumps = [...prev.boosterPumps]
         


### PR DESCRIPTION
## Summary
- remove an unused `runningPumps` declaration in `WaterPlantDemo` that was causing a redeclaration error

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: TypeScript errors and missing dependencies)*
- `npx vite` *(fails: vite not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c080143e8832cb33e0ead9068d921