### PR TITLE
Fix jitter validation and benchmark config

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -480,6 +480,18 @@ impl Engine {
         
         // Validate configuration
         config.validate()?;
+
+        debug!(
+            "Engine validation: scan_time={}ms, max_jitter={}ms",
+            config.scan_time_ms,
+            config.max_scan_jitter_ms
+        );
+
+        if config.max_scan_jitter_ms > config.scan_time_ms {
+            return Err(PlcError::Config(
+                "Maximum jitter cannot exceed scan time".to_string(),
+            ));
+        }
         
         // Initialize signals from configuration
         Self::initialize_signals(&bus, &config)?;


### PR DESCRIPTION
## Summary
- tighten benchmark jitter to 20ms
- allow jitter equal to scan time in validation with warnings
- add helper `recommended_jitter_limit`
- expose debug check in engine constructor
- add unit tests for jitter validation

## Testing
- `cargo test --lib --tests --quiet` *(fails: could not compile `petra` (lib test) due to 33 previous errors)*

------
https://chatgpt.com/codex/tasks/task_e_686c3cc13f90832cafa993f46cec966f