### PR TITLE
Fix blank screen due to missing deps

### DIFF
--- a/petra-designer/package.json
+++ b/petra-designer/package.json
@@ -20,7 +20,10 @@
     "react-icons": "^5.0.1",
     "prismjs": "^1.29.0",
     "react-simple-code-editor": "^0.13.1",
-    "nanoid": "^5.0.4"
+    "nanoid": "^5.0.4",
+    "react-konva": "^19.0.7",
+    "konva": "^9.3.12",
+    "react-color": "^2.19.3"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/petra-designer/src/components/hmi/WaterPlantDemo.tsx
+++ b/petra-designer/src/components/hmi/WaterPlantDemo.tsx
@@ -7,7 +7,7 @@ import TankComponent from './components/TankComponent'
 import PumpComponent from './components/PumpComponent'
 import ValveComponent from './components/ValveComponent'
 import GaugeComponent from './components/GaugeComponent'
-import { usePetraContext } from '../../contexts/PetraContext'
+import { usePetra } from '../../contexts/PetraContext'
 
 interface SimulationState {
   running: boolean
@@ -17,7 +17,7 @@ interface SimulationState {
 }
 
 export default function WaterPlantPetraDemo() {
-  const { signalBus, isConnected } = usePetraContext()
+  const { signalBus, isConnected } = usePetra()
   
   const [simulation, setSimulation] = useState<SimulationState>({
     running: true,


### PR DESCRIPTION
## Summary
- add missing `react-konva`, `konva` and `react-color` dependencies
- update WaterPlantDemo hook usage to `usePetra`

## Testing
- `npm install`
- `npm run dev`
- `npm run build` *(fails: TS errors)*
- `cargo test` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_686c4483affc832cbe7e34bf141ea96f