### PR TITLE
Fix Vite alias resolution

### DIFF
--- a/petra-designer/vite.config.ts
+++ b/petra-designer/vite.config.ts
@@ -1,12 +1,12 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import path from 'path'
+import { fileURLToPath, URL } from 'node:url'
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
   server: {


### PR DESCRIPTION
## Summary
- use `import.meta.url` in designer `vite.config.ts` for stable `@` alias resolution

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails to compile TypeScript)*

------
https://chatgpt.com/codex/tasks/task_e_686c92eeceac832cb6835a83be30548a