### PR TITLE
Fix missing modules and feature imports

### DIFF
--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -37,6 +37,7 @@ use crate::{
     config::BlockConfig,
     error::{PlcError, Result},
     signal::SignalBus,
+    Value,
 };
 use std::collections::HashMap;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -207,8 +207,11 @@ pub enum PlcError {
     /// Automatically converts from `tokio_modbus::Error` and covers
     /// Modbus TCP/RTU communication failures.
     #[cfg(feature = "modbus-support")]
-    #[error("Modbus error")]
-    Modbus(#[from] tokio_modbus::Error),
+    #[error("Modbus error: {source}")]
+    Modbus {
+        #[source]
+        source: std::io::Error,
+    },
     
     /// OPC-UA protocol error
     /// 
@@ -542,7 +545,7 @@ impl PlcError {
             Self::S7(_) => ErrorCategory::Communication,
             
             #[cfg(feature = "modbus-support")]
-            Self::Modbus(_) => ErrorCategory::Communication,
+            Self::Modbus { .. } => ErrorCategory::Communication,
             
             #[cfg(feature = "opcua-support")]
             Self::OpcUa(_) => ErrorCategory::Communication,
@@ -628,7 +631,7 @@ impl PlcError {
             Self::S7(_) => 6002,
             
             #[cfg(feature = "modbus-support")]
-            Self::Modbus(_) => 6003,
+            Self::Modbus { .. } => 6003,
             
             #[cfg(feature = "opcua-support")]
             Self::OpcUa(_) => 6004,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,7 @@ pub mod validation {
 // MONITORING MODULES (Feature-Gated)
 // ============================================================================
 
-#[cfg(feature = "metrics")]
+#[cfg(any(feature = "metrics", feature = "enhanced-monitoring"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
 /// Prometheus metrics server for observability
 /// 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,25 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+#[derive(Debug, Default)]
+pub struct EngineMetrics {
+    total_scans: AtomicU64,
+    total_errors: AtomicU64,
+    total_scan_time_us: AtomicU64,
+}
+
+impl EngineMetrics {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn record_scan(&self, duration: Duration) {
+        self.total_scans.fetch_add(1, Ordering::Relaxed);
+        self.total_scan_time_us
+            .fetch_add(duration.as_micros() as u64, Ordering::Relaxed);
+    }
+
+    pub fn record_error(&self) {
+        self.total_errors.fetch_add(1, Ordering::Relaxed);
+    }
+}

--- a/src/protocols/modbus.rs
+++ b/src/protocols/modbus.rs
@@ -1,1 +1,1 @@
-pub use crate::modbus::*;
+pub use crate::modbus;

--- a/src/protocols/opcua.rs
+++ b/src/protocols/opcua.rs
@@ -1,1 +1,1 @@
-pub use crate::opcua::*;
+pub use crate::opcua;

--- a/src/protocols/s7.rs
+++ b/src/protocols/s7.rs
@@ -1,1 +1,1 @@
-pub use crate::s7::*;
+pub use crate::s7;

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -54,6 +54,8 @@ use tracing::{debug, trace, warn};
 // Feature-gated imports for enhanced functionality
 #[cfg(feature = "enhanced-monitoring")]
 use std::collections::VecDeque;
+#[cfg(feature = "enhanced-monitoring")]
+use std::time::{Duration, Instant};
 
 #[cfg(feature = "signal-validation")]
 use crate::validation::Validator;

--- a/src/storage/metrics.rs
+++ b/src/storage/metrics.rs
@@ -1,0 +1,44 @@
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use tracing::info;
+
+use super::StorageMetricsSnapshot;
+
+#[derive(Debug, Default)]
+pub struct StorageMetrics {
+    pub write_count: AtomicU64,
+    pub query_count: AtomicU64,
+    pub bytes_written: AtomicU64,
+    pub bytes_read: AtomicU64,
+    pub active_connections: AtomicU32,
+    pub error_count: AtomicU64,
+}
+
+impl StorageMetrics {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn snapshot(&self) -> StorageMetricsSnapshot {
+        StorageMetricsSnapshot {
+            write_count: self.write_count.load(Ordering::Relaxed),
+            query_count: self.query_count.load(Ordering::Relaxed),
+            bytes_written: self.bytes_written.load(Ordering::Relaxed),
+            bytes_read: self.bytes_read.load(Ordering::Relaxed),
+            active_connections: self.active_connections.load(Ordering::Relaxed),
+            error_count: self.error_count.load(Ordering::Relaxed),
+        }
+    }
+
+    pub fn report(&self) {
+        let snap = self.snapshot();
+        info!(
+            "Storage metrics: writes={} queries={} bytes_written={} bytes_read={} connections={} errors={}",
+            snap.write_count,
+            snap.query_count,
+            snap.bytes_written,
+            snap.bytes_read,
+            snap.active_connections,
+            snap.error_count
+        );
+    }
+}

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1,0 +1,20 @@
+#[cfg(feature = "health")]
+pub mod health;
+
+#[cfg(feature = "web")]
+use axum::{routing::get, Router, serve};
+#[cfg(feature = "web")]
+use crate::error::Result;
+
+#[cfg(feature = "web")]
+pub async fn start_server() -> Result<()> {
+    let app = Router::new();
+    #[cfg(feature = "health")]
+    let app = app.route("/health", get(|| async { "OK" }));
+
+    use std::net::SocketAddr;
+    let addr: SocketAddr = "0.0.0.0:8080".parse().unwrap();
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    serve(listener, app.into_make_service()).await?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add skeleton modules for metrics and web features
- add storage metrics helpers
- adjust protocol re-exports
- fix conditional compilation for metrics
- import missing types when `enhanced-monitoring` is enabled

## Testing
- `cargo check`
- `cargo check --no-default-features --features "modbus-support s7-support"`
- `cargo check --no-default-features --features "web health metrics enhanced-monitoring"`
- `cargo test --no-run` *(fails: could not compile `petra`)*

------
https://chatgpt.com/codex/tasks/task_e_686d2c808268832c9012f9e81cdd551b