### PR TITLE
Fix web/metrics build errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,10 +136,11 @@ cranelift-jit = { version = "0.100", optional = true }
 # HTTP client/server and web framework dependencies
 # Used by web interface, health endpoints, and REST APIs
 reqwest = { version = "0.12", features = ["json"], optional = true }
-axum = { version = "0.6", optional = true }
+axum = { version = "0.6", features = ["ws"], optional = true }
 tower = { version = "0.5", optional = true }
 tower-http = { version = "0.4", features = ["cors"], optional = true }
 prometheus = { version = "0.13", optional = true }
+metrics-exporter-prometheus = { version = "0.13", optional = true }
 hyper = { version = "1.4", optional = true }        # HTTP implementation
 sysinfo = { version = "0.32", optional = true }     # System information for health
 
@@ -373,7 +374,7 @@ standard-monitoring = ["basic-monitoring"]              # Standard performance t
 enhanced-monitoring = ["standard-monitoring", "dep:ringbuffer"]  # Advanced monitoring with detailed stats
 
 # === METRICS INTEGRATION ===
-metrics = ["prometheus"]
+metrics = ["prometheus", "metrics-exporter-prometheus"]
 
 # ================================================================================
 # PROTOCOL FEATURES
@@ -487,7 +488,7 @@ full-alarms = ["basic-alarms", "twilio"]              # All notification methods
 # HTTP server and web interface capabilities
 
 # === WEB FRAMEWORK ===
-web = ["axum", "tower-http", "tokio/net"]
+web = ["axum", "tower-http", "tokio/net", "dep:reqwest"]
 
 # === HEALTH MONITORING ===
 health = ["dep:axum", "dep:tower", "dep:tower-http", "dep:sysinfo"]  # Health check endpoints

--- a/src/error.rs
+++ b/src/error.rs
@@ -997,6 +997,24 @@ macro_rules! validation_error {
 }
 
 // ============================================================================
+// WEB RESPONSE INTEGRATION
+// ============================================================================
+
+#[cfg(feature = "web")]
+impl axum::response::IntoResponse for PlcError {
+    fn into_response(self) -> axum::response::Response {
+        use axum::{Json, http::StatusCode, response::IntoResponse as _};
+        let status = match self {
+            PlcError::SignalNotFound(_) => StatusCode::NOT_FOUND,
+            PlcError::Validation(_) => StatusCode::BAD_REQUEST,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        let body = Json(serde_json::json!({ "error": self.to_string() }));
+        (status, body).into_response()
+    }
+}
+
+// ============================================================================
 // COMPREHENSIVE TESTS
 // ============================================================================
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,10 +266,14 @@ pub mod validation {
 #[cfg(any(feature = "metrics", feature = "enhanced-monitoring"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
 /// Prometheus metrics server for observability
-/// 
+///
 /// Production-ready metrics endpoint with comprehensive system
 /// and application metrics for monitoring and alerting.
 pub mod metrics;
+
+#[cfg(feature = "metrics")]
+#[cfg_attr(docsrs, doc(cfg(feature = "metrics")))]
+pub mod metrics_server;
 
 #[cfg(feature = "health")]
 #[cfg_attr(docsrs, doc(cfg(feature = "health")))]
@@ -351,6 +355,9 @@ pub use config::{Config, BlockConfig, SignalConfig, LintSeverity, LintResult};
 pub use engine::EngineConfig;
 pub use engine::Engine;
 pub use features::{Features, RuntimeFeatures};
+
+#[cfg(feature = "metrics")]
+pub use metrics_server::MetricsServer;
 
 // Re-export commonly used protocol modules for convenience
 #[cfg(feature = "modbus-support")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1520,12 +1520,10 @@ async fn handle_protocol_command(cmd: ProtocolCommands) -> Result<()> {
 async fn start_metrics_server(port: u16, bind: String, runtime_metrics: bool) -> Result<()> {
     info!("Starting metrics server on {}:{}", bind, port);
     
-    let mut server = MetricsServer::new(&bind, port)?;
-    
+    let mut server = MetricsServer::new_with_addr(&bind, port)?;
     if runtime_metrics {
         server.enable_runtime_metrics();
     }
-    
     server.start().await?;
     
     // Wait for shutdown signal

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides system metrics collection and reporting.
 
-use prometheus::{Counter, Gauge, Histogram, Registry};
+use prometheus::{Counter, Gauge, Histogram, HistogramOpts, Opts, Registry};
 
 #[derive(Clone)]
 pub struct EngineMetrics {
@@ -14,9 +14,9 @@ pub struct EngineMetrics {
 }
 
 impl EngineMetrics {
-    pub fn new(registry: &Registry) -> Result<Self, prometheus::Error> {
+    pub fn new(registry: &Registry) -> std::result::Result<Self, prometheus::Error> {
         let scan_duration = Histogram::with_opts(
-            prometheus::HistogramOpts::new(
+            HistogramOpts::new(
                 "petra_scan_duration_seconds",
                 "Scan cycle duration in seconds",
             )
@@ -25,7 +25,7 @@ impl EngineMetrics {
         registry.register(Box::new(scan_duration.clone()))?;
 
         let block_executions = Counter::with_opts(
-            prometheus::CounterOpts::new(
+            Opts::new(
                 "petra_block_executions_total",
                 "Total number of block executions",
             ),
@@ -33,7 +33,7 @@ impl EngineMetrics {
         registry.register(Box::new(block_executions.clone()))?;
 
         let signal_updates = Counter::with_opts(
-            prometheus::CounterOpts::new(
+            Opts::new(
                 "petra_signal_updates_total",
                 "Total number of signal updates",
             ),
@@ -41,7 +41,7 @@ impl EngineMetrics {
         registry.register(Box::new(signal_updates.clone()))?;
 
         let active_signals = Gauge::with_opts(
-            prometheus::GaugeOpts::new(
+            Opts::new(
                 "petra_active_signals",
                 "Number of active signals",
             ),
@@ -49,7 +49,7 @@ impl EngineMetrics {
         registry.register(Box::new(active_signals.clone()))?;
 
         let errors = Counter::with_opts(
-            prometheus::CounterOpts::new("petra_errors_total", "Total number of errors"),
+            Opts::new("petra_errors_total", "Total number of errors"),
         )?;
         registry.register(Box::new(errors.clone()))?;
 


### PR DESCRIPTION
## Summary
- add missing prometheus metrics exporter and reqwest dependencies
- support websocket feature in axum
- implement `IntoResponse` for `PlcError`
- update metrics module and metrics server
- expose metrics server through library
- adjust CLI metrics server code

## Testing
- `cargo check --features web,metrics --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686d3e35f2c8832c8d513ed65e55ffbb