### PR TITLE
Fix metrics feature compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ uuid = { version = "1.10", features = ["v4", "serde"] }  # Unique identifiers
 base64 = { version = "0.22", optional = true }  # Base64 encoding for security
 once_cell = { version = "1.20", optional = true }  # Lazy static initialization
 regex = "1.11"  # Regular expressions for validation
+async-trait = "0.1"
 
 # === HIGH-PERFORMANCE COLLECTIONS ===
 # Concurrent data structures for signal bus and shared state
@@ -374,7 +375,7 @@ standard-monitoring = ["basic-monitoring"]              # Standard performance t
 enhanced-monitoring = ["standard-monitoring", "dep:ringbuffer"]  # Advanced monitoring with detailed stats
 
 # === METRICS INTEGRATION ===
-metrics = ["prometheus", "metrics-exporter-prometheus"]
+metrics = ["prometheus", "metrics-exporter-prometheus", "axum", "web"]
 
 # ================================================================================
 # PROTOCOL FEATURES

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,51 +120,10 @@ pub mod blocks;
 // ============================================================================
 
 /// Industrial and IoT protocol implementations
-/// 
+///
 /// Protocol drivers for industrial automation and IoT communication.
 /// Each protocol is feature-gated for modular compilation.
-pub mod protocols {
-    //! Protocol driver framework and implementations
-    //! 
-    //! Provides a common interface for all protocol drivers with
-    //! async support, connection management, and error handling.
-
-    #[cfg(feature = "mqtt")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "mqtt")))]
-    /// MQTT protocol support for IoT and edge device communication
-    /// 
-    /// High-performance MQTT client with automatic reconnection,
-    /// QoS support, and integration with the signal bus.
-    pub mod mqtt;
-
-    #[cfg(feature = "s7-support")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "s7-support")))]
-    /// Siemens S7 PLC communication driver
-    /// 
-    /// Native S7 protocol implementation for direct communication
-    /// with Siemens PLCs supporting read/write operations.
-    pub mod s7;
-
-    #[cfg(feature = "modbus-support")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "modbus-support")))]
-    /// Modbus TCP/RTU protocol driver
-    /// 
-    /// Standards-compliant Modbus implementation supporting both
-    /// TCP and RTU variants with automatic device discovery.
-    pub mod modbus;
-
-    #[cfg(feature = "opcua-support")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "opcua-support")))]
-    /// OPC-UA server implementation
-    ///
-    /// Full OPC-UA server with subscription support, security,
-    /// and standards-compliant information modeling.
-    pub mod opcua;
-
-    /// Zero-copy protocol utilities and traits
-    #[cfg(feature = "zero-copy-protocols")]
-    pub mod zero_copy;
-}
+pub mod protocols;
 
 #[cfg(feature = "mqtt")]
 pub mod mqtt {

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -588,9 +588,10 @@ impl ProtocolManager {
             );
             
             // Add protocol name
+            #[cfg(feature = "extended-types")]
             diag.insert(
-                "protocol".to_string(), 
-                Value::String(driver.protocol_name().to_string())
+                "protocol".to_string(),
+                Value::String(driver.protocol_name().to_string()),
             );
             
             #[cfg(feature = "enhanced-monitoring")]
@@ -606,7 +607,13 @@ impl ProtocolManager {
                     diag.insert("error_count".to_string(), Value::Integer(*error_count as i64));
                 }
                 if let Some(last_error) = metrics.last_error.get(name) {
-                    diag.insert("last_error".to_string(), Value::String(last_error.clone()));
+                    #[cfg(feature = "extended-types")]
+                    {
+                        diag.insert(
+                            "last_error".to_string(),
+                            Value::String(last_error.clone()),
+                        );
+                    }
                 }
             }
             
@@ -635,7 +642,11 @@ impl ProtocolManager {
         if let Some(driver) = drivers.get(protocol) {
             let mut diag = driver.diagnostics();
             diag.insert("connected".to_string(), Value::Bool(driver.is_connected()));
-            diag.insert("protocol".to_string(), Value::String(driver.protocol_name().to_string()));
+            #[cfg(feature = "extended-types")]
+            diag.insert(
+                "protocol".to_string(),
+                Value::String(driver.protocol_name().to_string()),
+            );
             Ok(diag)
         } else {
             Err(crate::error::PlcError::NotFound(
@@ -825,7 +836,11 @@ mod tests {
         // Get diagnostics
         let diag = manager.protocol_diagnostics("mock").await.unwrap();
         assert_eq!(diag.get("connected"), Some(&Value::Bool(true)));
-        assert_eq!(diag.get("protocol"), Some(&Value::String("mock".to_string())));
+        #[cfg(feature = "extended-types")]
+        assert_eq!(
+            diag.get("protocol"),
+            Some(&Value::String("mock".to_string()))
+        );
         assert_eq!(diag.get("test_mode"), Some(&Value::Bool(true)));
         
         // Get all diagnostics


### PR DESCRIPTION
## Summary
- include `async-trait` dependency
- make `metrics` feature depend on `axum` and `web`
- load real protocol framework instead of empty stub
- gate Value::String diagnostics behind `extended-types`

## Testing
- `cargo check`
- `cargo check --features metrics`

------
https://chatgpt.com/codex/tasks/task_e_686d648caccc832ca8361878d272f52b