### PR TITLE
Fix metrics build with enhanced-monitoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -372,7 +372,7 @@ mqtt-bridge = ["mqtt"]      # MQTT bridging support
 # === MONITORING LEVELS ===
 basic-monitoring = []                                    # Minimal monitoring
 standard-monitoring = ["basic-monitoring"]              # Standard performance tracking
-enhanced-monitoring = ["standard-monitoring", "dep:ringbuffer"]  # Advanced monitoring with detailed stats
+enhanced-monitoring = ["standard-monitoring", "dep:ringbuffer", "prometheus"]  # Advanced monitoring with detailed stats
 
 # === METRICS INTEGRATION ===
 metrics = ["prometheus", "metrics-exporter-prometheus", "axum", "web"]

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -37,12 +37,14 @@ use crate::{
     config::BlockConfig,
     error::{PlcError, Result},
     signal::SignalBus,
-    Value,
 };
+
+#[cfg(feature = "enhanced-monitoring")]
+use crate::Value;
 use std::collections::HashMap;
 
 #[cfg(feature = "enhanced-monitoring")]
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 #[cfg(feature = "json-schema")]
 use schemars::JsonSchema;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -509,6 +509,12 @@ impl Engine {
         // Calculate EMA alpha based on scan time
         let ema_alpha = 2.0 / (10.0 + 1.0); // 10-period EMA
         
+        #[cfg(feature = "enhanced-monitoring")]
+        let registry = crate::metrics::create_metrics_registry();
+        #[cfg(feature = "enhanced-monitoring")]
+        let metrics = Arc::new(EngineMetrics::new(&registry)
+            .map_err(|e| PlcError::Runtime(e.to_string()))?);
+
         let engine = Self {
             bus,
             blocks: Arc::new(Mutex::new(blocks)),
@@ -529,7 +535,7 @@ impl Engine {
             last_scan_start: Arc::new(RwLock::new(Instant::now())),
             ema_alpha,
             #[cfg(feature = "enhanced-monitoring")]
-            metrics: Arc::new(EngineMetrics::new()),
+            metrics,
             watchdog_handle: None,
             last_watchdog_ping: Arc::new(RwLock::new(Instant::now())),
             #[cfg(feature = "parallel-execution")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1003,14 +1003,14 @@ macro_rules! validation_error {
 #[cfg(feature = "web")]
 impl axum::response::IntoResponse for PlcError {
     fn into_response(self) -> axum::response::Response {
-        use axum::{Json, http::StatusCode, response::IntoResponse as _};
+        use axum::{Json, http::StatusCode};
         let status = match self {
             PlcError::SignalNotFound(_) => StatusCode::NOT_FOUND,
             PlcError::Validation(_) => StatusCode::BAD_REQUEST,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
         let body = Json(serde_json::json!({ "error": self.to_string() }));
-        (status, body).into_response()
+        axum::response::IntoResponse::into_response((status, body))
     }
 }
 

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -606,12 +606,12 @@ impl ProtocolManager {
                 if let Some(error_count) = metrics.error_count.get(name) {
                     diag.insert("error_count".to_string(), Value::Integer(*error_count as i64));
                 }
-                if let Some(last_error) = metrics.last_error.get(name) {
+                if let Some(_last_error) = metrics.last_error.get(name) {
                     #[cfg(feature = "extended-types")]
                     {
                         diag.insert(
                             "last_error".to_string(),
-                            Value::String(last_error.clone()),
+                            Value::String(_last_error.clone()),
                         );
                     }
                 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -3,7 +3,7 @@ use axum::{
     extract::{State, WebSocketUpgrade},
     response::IntoResponse,
     routing::{get, post},
-    Json, Router,
+    Router,
 };
 use std::sync::Arc;
 use tokio::sync::RwLock;

--- a/src/web/websocket.rs
+++ b/src/web/websocket.rs
@@ -2,7 +2,7 @@ use axum::extract::ws::{Message, WebSocket};
 use futures::{sink::SinkExt, stream::StreamExt};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
-use crate::{PlcError, Value};
+use crate::Value;
 use super::AppState;
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- fix `Cargo.toml` feature dependencies so `enhanced-monitoring` pulls in Prometheus
- adjust imports and remove unused items to silence warnings
- create metrics registry when initializing the engine
- update `IntoResponse` implementation for `PlcError`
- fix unused variable in protocols

## Testing
- `cargo check --features enhanced-monitoring`
- `cargo check --features metrics`
- `cargo test --no-run --features enhanced-monitoring` *(fails: could not compile `petra` (lib test) due to 33 previous errors)*

------
https://chatgpt.com/codex/tasks/task_e_686d67cff80c832ca0f21dc8678c0016