### PR TITLE
Add protocol test_connection stubs

### DIFF
--- a/src/protocols/modbus.rs
+++ b/src/protocols/modbus.rs
@@ -5,6 +5,7 @@
 use crate::{Result, Value};
 use async_trait::async_trait;
 use std::collections::HashMap;
+use tracing::info;
 
 pub struct ModbusDriver {
     // Implementation details
@@ -39,4 +40,11 @@ impl crate::protocols::ProtocolDriver for ModbusDriver {
     fn protocol_name(&self) -> &'static str {
         "modbus"
     }
+}
+
+/// Test connectivity to a Modbus device.
+/// This is a lightweight stub used by the command-line interface.
+pub async fn test_connection(_address: &str, _unit_id: u8, _register: u16) -> Result<()> {
+    info!("Modbus test_connection stub called");
+    Ok(())
 }

--- a/src/protocols/opcua.rs
+++ b/src/protocols/opcua.rs
@@ -5,6 +5,7 @@
 use crate::{Result, Value};
 use async_trait::async_trait;
 use std::collections::HashMap;
+use tracing::info;
 
 pub struct OpcUaDriver {
     // Implementation details
@@ -39,4 +40,11 @@ impl crate::protocols::ProtocolDriver for OpcUaDriver {
     fn protocol_name(&self) -> &'static str {
         "opcua"
     }
+}
+
+/// Test connectivity to an OPC UA endpoint.
+/// This is a lightweight stub used by the command-line interface.
+pub async fn test_connection(_endpoint: &str, _node_id: Option<&str>) -> Result<()> {
+    info!("OPC UA test_connection stub called");
+    Ok(())
 }

--- a/src/protocols/s7.rs
+++ b/src/protocols/s7.rs
@@ -5,6 +5,7 @@
 use crate::{Result, Value};
 use async_trait::async_trait;
 use std::collections::HashMap;
+use tracing::info;
 
 pub struct S7Driver {
     // Implementation details
@@ -39,4 +40,11 @@ impl crate::protocols::ProtocolDriver for S7Driver {
     fn protocol_name(&self) -> &'static str {
         "s7"
     }
+}
+
+/// Test connectivity to an S7 PLC.
+/// This is a lightweight stub used by the command-line interface.
+pub async fn test_connection(_address: &str, _rack: u16, _slot: u16) -> Result<()> {
+    info!("S7 test_connection stub called");
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- implement placeholder `test_connection` functions for Modbus, S7 and OPC UA
- log stub usage via tracing

## Testing
- `cargo check --locked`
- `cargo test --locked --no-run` *(fails: could not compile `petra`)*

------
https://chatgpt.com/codex/tasks/task_e_686d74111b58832c8a7d13b2a2023d4a