### PR TITLE
Fix TypeScript warnings in hooks

### DIFF
--- a/petra-designer/src/hooks/useBlockStatus.ts
+++ b/petra-designer/src/hooks/useBlockStatus.ts
@@ -10,7 +10,7 @@ interface BlockStatus {
 }
 
 export function useBlockStatus() {
-  const [blockStatus, setBlockStatus] = useState<Map<string, BlockStatus>>(new Map())
+  const [blockStatus] = useState<Map<string, BlockStatus>>(new Map())
   usePetraConnection() // ensure connection is active
 
   const getBlockHealth = (id: string) => blockStatus.get(id)

--- a/petra-designer/src/hooks/useComponentTemplates.ts
+++ b/petra-designer/src/hooks/useComponentTemplates.ts
@@ -7,16 +7,14 @@ export function useComponentTemplates() {
       name: 'Motor Control',
       description: 'Standard motor with start/stop controls',
       component: {
-        type: 'group',
-        children: ['motor', 'button', 'indicator'] as any
+        type: 'group'
       }
     },
     {
       name: 'PID Loop',
       description: 'PID controller with setpoint and PV display',
       component: {
-        type: 'group',
-        children: ['gauge', 'trend', 'text'] as any
+        type: 'group'
       }
     }
   ]

--- a/petra-designer/src/hooks/useDataExport.ts
+++ b/petra-designer/src/hooks/useDataExport.ts
@@ -31,8 +31,8 @@ export function useDataExport() {
   }
 
   const generateReport = async (
-    type: 'summary' | 'alarm' | 'performance',
-    options: ReportOptions
+    _type: 'summary' | 'alarm' | 'performance',
+    _options: ReportOptions
   ) => {
     // Implementation placeholder
   }

--- a/petra-designer/src/hooks/useOfflineQueue.ts
+++ b/petra-designer/src/hooks/useOfflineQueue.ts
@@ -19,7 +19,7 @@ export function useOfflineQueue() {
     ])
   }
 
-  const sendMessage = async (msg: any) => {
+  const sendMessage = async (_msg: any) => {
     // Placeholder for actual send logic
     return Promise.resolve()
   }

--- a/petra-designer/src/hooks/useProtocols.ts
+++ b/petra-designer/src/hooks/useProtocols.ts
@@ -17,7 +17,7 @@ export interface ProtocolStatus {
 export function useProtocols() {
   const [protocols] = useState<Map<string, ProtocolStatus>>(new Map())
 
-  const restartProtocol = (name: string) => {
+  const restartProtocol = (_name: string) => {
     // TODO: implement restart logic
   }
 

--- a/petra-designer/src/hooks/useSignalHistory.ts
+++ b/petra-designer/src/hooks/useSignalHistory.ts
@@ -7,8 +7,8 @@ interface TimeRange {
   end: number
 }
 
-export function useSignalHistory(signal: string, timeRange: TimeRange) {
-  const [history, setHistory] = useState<HistoryData[]>([])
+export function useSignalHistory(_signal: string, _timeRange: TimeRange) {
+  const [history] = useState<HistoryData[]>([])
   const [loading, setLoading] = useState(false)
 
   const refresh = async () => {


### PR DESCRIPTION
## Summary
- remove unused variables in multiple hooks
- drop unsupported `children` field from component templates

## Testing
- `npm run build` *(fails: Cannot find module '@xyflow/react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686d762b86b4832caef0014f626b0eff