### PR TITLE
Add web server startup in run mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,10 @@ use petra::{
 use petra::build_info;
 use std::path::PathBuf;
 use std::process;
+#[cfg(feature = "web")]
+use std::sync::Arc;
+#[cfg(feature = "web")]
+use petra::web;
 use tokio::signal;
 use tracing::{info, error, debug, warn, Level};
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
@@ -920,7 +924,7 @@ async fn run_engine(
     info!("Configuration loaded successfully");
     
     // Create engine
-    let mut engine = Engine::new(config)?;
+    let mut engine = Engine::new(config.clone())?;
     
     // Configure optional features
     #[cfg(feature = "enhanced-monitoring")]
@@ -945,6 +949,32 @@ async fn run_engine(
     if let Some(affinity) = cpu_affinity {
         info!("Setting CPU affinity: {:?}", affinity);
         set_cpu_affinity(&affinity)?;
+    }
+
+    // Start the web server if configured
+    #[cfg(feature = "web")]
+    {
+        if let Some(web_config) = &config.web {
+            let web_bus = engine.signal_bus().clone();
+            let web_config_clone = config.clone();
+
+            tokio::spawn(async move {
+                if let Err(e) = web::create_server(
+                    Arc::new(web_bus.clone()),
+                    web_config_clone,
+                )
+                .await
+                {
+                    error!("Web server error: {}", e);
+                }
+            });
+
+            info!(
+                "Web server started on {}:{}",
+                web_config.bind_address,
+                web_config.port
+            );
+        }
     }
     
     // Start the engine
@@ -1671,3 +1701,53 @@ async fn handle_storage_command(cmd: StorageCommands) -> Result<()> {
     }
     Ok(())
 }
+
+
+/// Handle running the engine with basic options
+async fn handle_run(config_file: PathBuf) -> Result<()> {
+    info!("Loading configuration from: {}", config_file.display());
+
+    let config = Config::from_file(&config_file)
+        .map_err(|e| PlcError::Config(format!("Failed to load config: {}", e)))?;
+    let mut engine = Engine::new(config.clone())?;
+
+    // Start the web server if configured
+    #[cfg(feature = "web")]
+    {
+        if let Some(web_config) = &config.web {
+            let web_bus = engine.signal_bus().clone();
+            let web_config_clone = config.clone();
+
+                tokio::spawn(async move {
+                    if let Err(e) = web::create_server(
+                        Arc::new(web_bus.clone()),
+                        web_config_clone,
+                    )
+                    .await
+                    {
+                        error!("Web server error: {}", e);
+                    }
+                });
+
+                info!(
+                    "Web server started on {}:{}",
+                    web_config.bind_address,
+                    web_config.port
+                );
+        }
+    }
+
+    let shutdown_signal = setup_shutdown_handler();
+    tokio::pin!(shutdown_signal);
+    tokio::select! {
+        res = engine.run() => { res?; }
+        _ = &mut shutdown_signal => {
+            info!("Shutdown signal received, stopping engine...");
+            engine.stop().await;
+        }
+    }
+    info!("Engine stopped successfully");
+
+    Ok(())
+}
+


### PR DESCRIPTION
## Summary
- spawn the web server when starting the engine from new `handle_run`
- import Arc and `petra::web` for server startup

## Testing
- `cargo check`
- `cargo check --no-default-features --features cli,web`


------
https://chatgpt.com/codex/tasks/task_e_686d85b41f10832cb4f0852920dbe0d9