### PR TITLE
Fix WiFi icon import

### DIFF
--- a/petra-designer/src/components/Toolbar.tsx
+++ b/petra-designer/src/components/Toolbar.tsx
@@ -34,10 +34,10 @@ import {
   FaChartLine,
   FaServer,
   FaWifi,
-  FaWifiSlash,
   FaMoon,
   FaSun
 } from 'react-icons/fa'
+import { MdWifiOff } from 'react-icons/md'
 import { useFlowStore } from '@/store/flowStore'
 import { usePetra } from '@/contexts/PetraContext'
 
@@ -318,7 +318,7 @@ export default function EnhancedToolbar({
                 </>
               ) : (
                 <>
-                  <FaWifiSlash className="w-3 h-3" />
+                  <MdWifiOff className="w-3 h-3" />
                   <span>Disconnected</span>
                 </>
               )}


### PR DESCRIPTION
## Summary
- use `MdWifiOff` in the Toolbar component instead of the missing `FaWifiSlash` icon

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails to compile TypeScript files)*
- `cargo test` *(fails to compile the Rust project)*

------
https://chatgpt.com/codex/tasks/task_e_686dfaffac94832ca87eddc2c50f6e4e