### PR TITLE
Fix draggable for HMI components

### DIFF
--- a/petra-designer/src/components/hmi/components/ISA101PumpComponent.tsx
+++ b/petra-designer/src/components/hmi/components/ISA101PumpComponent.tsx
@@ -66,6 +66,7 @@ interface ISA101PumpProps {
   selected?: boolean
   onContextMenu?: (e: any) => void
   onClick?: () => void
+  [key: string]: any
 }
 
 export default function ISA101PumpComponent({
@@ -77,7 +78,8 @@ export default function ISA101PumpComponent({
   style = {},
   selected = false,
   onContextMenu,
-  onClick
+  onClick,
+  ...rest
 }: ISA101PumpProps) {
   const [blinkState, setBlinkState] = useState(true)
   const [rotation, setRotation] = useState(0)
@@ -128,7 +130,7 @@ export default function ISA101PumpComponent({
   const showAlarm = properties.alarmState !== 'none' && blinkState
   
   return (
-    <Group x={x} y={y} onClick={onClick} onContextMenu={onContextMenu}>
+    <Group x={x} y={y} onClick={onClick} onContextMenu={onContextMenu} {...rest}>
       {/* Selection indicator */}
       {selected && (
         <Rect

--- a/petra-designer/src/components/hmi/components/ISA101TankComponent.tsx
+++ b/petra-designer/src/components/hmi/components/ISA101TankComponent.tsx
@@ -77,6 +77,7 @@ interface ISA101TankProps {
   }
   selected?: boolean
   onContextMenu?: (e: any) => void
+  [key: string]: any
 }
 
 export default function ISA101TankComponent({
@@ -87,7 +88,8 @@ export default function ISA101TankComponent({
   properties,
   style = {},
   selected = false,
-  onContextMenu
+  onContextMenu,
+  ...rest
 }: ISA101TankProps) {
   const [animatedLevel, setAnimatedLevel] = useState(properties.currentLevel)
   const [trendData, setTrendData] = useState<number[]>([])
@@ -164,7 +166,7 @@ export default function ISA101TankComponent({
   const showAlarm = alarmColor && blinkState
   
   return (
-    <Group x={x} y={y} onContextMenu={onContextMenu}>
+    <Group x={x} y={y} onContextMenu={onContextMenu} {...rest}>
       {/* Selection indicator */}
       {selected && (
         <Rect

--- a/petra-designer/src/components/hmi/components/ISA101ValveComponent.tsx
+++ b/petra-designer/src/components/hmi/components/ISA101ValveComponent.tsx
@@ -52,6 +52,7 @@ interface ISA101ValveProps {
   selected?: boolean
   onContextMenu?: (e: any) => void
   onClick?: () => void
+  [key: string]: any
 }
 
 export default function ISA101ValveComponent({
@@ -63,7 +64,8 @@ export default function ISA101ValveComponent({
   style = {},
   selected = false,
   onContextMenu,
-  onClick
+  onClick,
+  ...rest
 }: ISA101ValveProps) {
   const [blinkState, setBlinkState] = useState(true)
   
@@ -259,7 +261,7 @@ export default function ISA101ValveComponent({
   const showAlarm = (properties.travelAlarm || properties.positionDeviation) && blinkState
   
   return (
-    <Group x={x} y={y} onClick={onClick} onContextMenu={onContextMenu}>
+    <Group x={x} y={y} onClick={onClick} onContextMenu={onContextMenu} {...rest}>
       {/* Selection indicator */}
       {selected && (
         <Rect


### PR DESCRIPTION
## Summary
- forward extra props to ISA101Tank, ISA101Pump, and ISA101Valve components so drag handlers propagate
- ensure root `<Group>` elements use forwarded props when rendered
- update linting (npm install) and run cargo tests (failed due to missing structures)

## Testing
- `npm run lint`
- `cargo test` *(fails: could not compile `petra`)*

------
https://chatgpt.com/codex/tasks/task_e_686e71599e18832c83d2fb135b70bea7