### PR TITLE
Fix HMIDesigner JSX structure

### DIFF
--- a/petra-designer/src/components/hmi/HMIDesigner.tsx
+++ b/petra-designer/src/components/hmi/HMIDesigner.tsx
@@ -984,6 +984,11 @@ export default function ISA101HMIDesigner() {
                                   <option value="control">Control</option>
                                 </select>
                               </div>
+                            </>
+                          )}
+                        </div>
+                      </div>
+
                       {/* Signal Bindings */}
                       <div>
                         <h4 className="font-medium text-sm mb-2 flex items-center justify-between" 


### PR DESCRIPTION
## Summary
- close React fragments and divs in HMIDesigner
- fix IIFE closing

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to parse source for import analysis)*

------
https://chatgpt.com/codex/tasks/task_e_686ece10f950832cb92c1d356101b076