### PR TITLE
Add web hosting for ISA-101 designer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,9 +137,9 @@ cranelift-jit = { version = "0.100", optional = true }
 # HTTP client/server and web framework dependencies
 # Used by web interface, health endpoints, and REST APIs
 reqwest = { version = "0.12", features = ["json"], optional = true }
-axum = { version = "0.6", features = ["ws"], optional = true }
+axum = { version = "0.7", features = ["ws"], optional = true }
 tower = { version = "0.5", optional = true }
-tower-http = { version = "0.4", features = ["cors"], optional = true }
+tower-http = { version = "0.4", features = ["fs", "cors"], optional = true }
 prometheus = { version = "0.13", optional = true }
 metrics-exporter-prometheus = { version = "0.13", optional = true }
 hyper = { version = "1.4", optional = true }        # HTTP implementation

--- a/petra-designer/package.json
+++ b/petra-designer/package.json
@@ -11,7 +11,10 @@
     "lint": "eslint \"src/**/*.{ts,tsx}\" --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {
-    "@xyflow/react": "^12.0.0",
+    "@xyflow/react": "latest",
+    "reactflow": "^11.10.1",
+    "recharts": "^2.9.3",
+    "lucide-react": "^0.292.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "zustand": "^4.5.0",

--- a/petra-designer/src/components/ISA101LogicDesigner.tsx
+++ b/petra-designer/src/components/ISA101LogicDesigner.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useRef } from 'react';
-import ReactFlow, { 
+import { ReactFlow,
   Node,
   Edge,
   Controls,
@@ -12,8 +12,8 @@ import ReactFlow, {
   useNodesState,
   useEdgesState,
   ReactFlowProvider
-} from 'reactflow';
-import 'reactflow/dist/style.css';
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
 
 // ISA-101 compliant colors
 const ISA_COLORS = {

--- a/petra-designer/src/types/hmi.ts
+++ b/petra-designer/src/types/hmi.ts
@@ -1,6 +1,6 @@
 // src/types/hmi.ts
 
-export type HMIComponentType = 
+export type HMIComponentType =
   | 'tank'
   | 'pump'
   | 'valve'
@@ -18,6 +18,15 @@ export type HMIComponentType =
   | 'heat-exchanger'
   | 'conveyor'
   | 'mixer'
+  
+export interface ConnectionInfo {
+  status: 'connected' | 'disconnected' | 'connecting' | 'error'
+  latency: number
+  uptime: number
+  lastError?: string
+  messageRate: number
+  reconnectAttempts: number
+}
 
 export interface HMIComponent {
   id: string

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -8,6 +8,10 @@ use axum::{
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tower_http::cors::CorsLayer;
+use tower_http::services::ServeDir;
+
+mod static_files;
+use static_files::spa_fallback;
 
 pub mod handlers;
 pub mod websocket;
@@ -32,6 +36,8 @@ pub async fn create_server(signal_bus: Arc<SignalBus>, config: crate::Config) ->
         .route("/api/config", get(handlers::get_config))
         .route("/api/config", post(handlers::update_config))
         .route("/ws", get(websocket_handler))
+        .nest_service("/", ServeDir::new("petra-designer/dist"))
+        .fallback(spa_fallback)
         .layer(CorsLayer::permissive())
         .with_state(state);
 

--- a/src/web/static_files.rs
+++ b/src/web/static_files.rs
@@ -1,0 +1,8 @@
+use axum::{response::{IntoResponse, Html}, http::StatusCode};
+
+pub async fn spa_fallback() -> impl IntoResponse {
+    match tokio::fs::read_to_string("petra-designer/dist/index.html").await {
+        Ok(content) => Html(content).into_response(),
+        Err(_) => (StatusCode::NOT_FOUND, "Not Found").into_response(),
+    }
+}

--- a/start-petra.sh
+++ b/start-petra.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Build frontend
+cd petra-designer
+npm install
+npm run build
+cd ..
+
+# Build backend with web support
+cargo build --features "web,mqtt,history,scada"


### PR DESCRIPTION
## Summary
- serve designer `dist` files via `axum` and add SPA fallback
- adjust dependencies for web server and frontend packages
- create helper `start-petra.sh`
- switch logic designer to `@xyflow/react`
- extend HMI types with `ConnectionInfo`

## Testing
- `npm install`
- `npm run build` *(failed: cannot find some modules)*
- `cargo build --features "web,mqtt,history,scada"` *(failed: couldn't find libclang)*

------
https://chatgpt.com/codex/tasks/task_e_686edae3b624832c97ae0fe2c0fa5c66