### PR TITLE
Fix web hook ref type and typing in designer

### DIFF
--- a/petra-designer/src/components/PropertiesPanel.tsx
+++ b/petra-designer/src/components/PropertiesPanel.tsx
@@ -20,6 +20,15 @@ import {
 import { validateNodeConfiguration } from '@/utils/validation'
 import toast from 'react-hot-toast'
 
+const getStringValue = (value: any): string => {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value
+  if (typeof value === 'number') return String(value)
+  if (typeof value === 'boolean') return String(value)
+  if (typeof value === 'object') return JSON.stringify(value)
+  return ''
+}
+
 type CategoryMap = Record<string, Array<{
   value: string
   label: string
@@ -280,7 +289,7 @@ function renderBlockParams(
                 </label>
                 <input
                   type="text"
-                  value={value || ''}
+                  value={getStringValue(value)}
                   onChange={(e) => updateParam(param.name, e.target.value)}
                   className="isa101-input w-full text-xs"
                 />
@@ -345,7 +354,7 @@ export default function PropertiesPanel() {
       </label>
       <input
         type={type}
-        value={(node.data as any)[field] || ''}
+        value={getStringValue((node.data as any)[field])}
         onChange={createChangeHandler(field)}
         className="isa101-input w-full text-xs"
         placeholder={placeholder}
@@ -360,7 +369,7 @@ export default function PropertiesPanel() {
         {label}
       </label>
       <select
-        value={(node.data as any)[field] || options[0]?.value}
+        value={getStringValue((node.data as any)[field]) || options[0]?.value}
         onChange={createChangeHandler(field)}
         className="isa101-input w-full text-xs"
       >
@@ -409,7 +418,7 @@ export default function PropertiesPanel() {
           </label>
           <input
             type="text"
-            value={node.data.label || ''}
+            value={getStringValue(node.data.label)}
             onChange={createChangeHandler('label')}
             className="isa101-input w-full text-xs"
             placeholder="Enter name"
@@ -700,7 +709,7 @@ export default function PropertiesPanel() {
                     Message Content
                   </label>
                   <textarea
-                    value={(node.data as TwilioNodeData).content || ''}
+                    value={getStringValue((node.data as TwilioNodeData).content)}
                     onChange={createChangeHandler('content')}
                     className="isa101-input w-full text-xs"
                     rows={3}

--- a/petra-designer/src/hooks/usePetraConnection.ts
+++ b/petra-designer/src/hooks/usePetraConnection.ts
@@ -87,7 +87,7 @@ export function usePetraConnection(options: UsePetraConnectionOptions = {}) {
   // Refs
   const wsRef = useRef<WebSocket | null>(null)
   const reconnectCountRef = useRef(0)
-  const pingIntervalRef = useRef<NodeJS.Timeout>()
+  const pingIntervalRef = useRef<number>()
   const messageRateRef = useRef<number[]>([])
   const subscribedSignalsRef = useRef<Set<string>>(new Set())
   const subscribedTopicsRef = useRef<Set<string>>(new Set())


### PR DESCRIPTION
## Summary
- fix web compatibility by using browser timer type
- add getStringValue helper for safe string coercion
- ensure properties panel uses helper to avoid type errors

## Testing
- `cargo test` *(fails: could not compile `petra` due to missing fields and types)*
- `npm run build` in `petra-designer` *(fails: TS errors about missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68701d7b02fc832ca1a041cebb0f8032