### PR TITLE
Fix type errors in petra-designer

### DIFF
--- a/petra-designer/src/components/PropertiesPanel.tsx
+++ b/petra-designer/src/components/PropertiesPanel.tsx
@@ -298,7 +298,7 @@ function renderBlockParams(blockData: BlockNodeData, updateNodeData: any, nodeId
             <label className="flex items-center gap-2 cursor-pointer">
               <input
                 type="checkbox"
-                checked={blockData.params?.[param.name] || false}
+                checked={Boolean(blockData.params?.[param.name])}
                 onChange={(e) => {
                   updateNodeData(nodeId, {
                     params: {
@@ -368,7 +368,7 @@ export default function PropertiesPanel() {
             </label>
             <input
               type="text"
-              value={node.data.label || ''}
+              value={String((node.data as any).label || '')}
               onChange={(e) => updateNodeData(node.id, { label: e.target.value })}
               className="isa101-input w-full text-xs"
             />
@@ -422,7 +422,11 @@ export default function PropertiesPanel() {
               ) : (
                 <input
                   type="number"
-                  value={(node.data as SignalNodeData).initial || 0}
+                  value={Number(
+                    typeof (node.data as SignalNodeData).initial === 'number'
+                      ? (node.data as SignalNodeData).initial
+                      : (node.data as SignalNodeData).initial
+                  )}
                   onChange={(e) => updateNodeData(node.id, { initial: parseFloat(e.target.value) })}
                   step={(node.data as SignalNodeData).signalType === 'float' ? '0.1' : '1'}
                   className="isa101-input w-full text-xs"

--- a/petra-designer/src/components/Sidebar.tsx
+++ b/petra-designer/src/components/Sidebar.tsx
@@ -18,8 +18,25 @@ import {
 } from 'react-icons/fa'
 import { PETRA_BLOCKS } from '@/nodes/BlockNode'
 
+interface ComponentEntry {
+  id: string
+  type: string
+  label: string
+  description: string
+  tags: string[]
+  complexity: string
+  blockType?: keyof typeof PETRA_BLOCKS
+}
+
+interface Category {
+  id: string
+  name: string
+  icon: JSX.Element
+  components: ComponentEntry[]
+}
+
 // Complete PETRA block library
-const componentCategories = [
+const componentCategories: Category[] = [
   {
     id: 'logic',
     name: 'Logic Gates',

--- a/petra-designer/src/nodes/BlockNode.tsx
+++ b/petra-designer/src/nodes/BlockNode.tsx
@@ -1,6 +1,6 @@
 // petra-designer/src/nodes/BlockNode.tsx
 import React from 'react'
-import { Handle, Position, type NodeProps } from '@xyflow/react'
+import { Handle, Position, type NodeProps, type Node } from '@xyflow/react'
 import type { BlockNodeData } from '@/types/nodes'
 
 // PETRA backend block configurations
@@ -154,7 +154,7 @@ const PETRA_BLOCKS = {
   }
 }
 
-export default function BlockNode({ data, selected }: NodeProps<BlockNodeData>) {
+export default function BlockNode({ data, selected }: NodeProps<Node<BlockNodeData>>) {
   const blockType = data.blockType
   const config = PETRA_BLOCKS[blockType as keyof typeof PETRA_BLOCKS]
   
@@ -165,18 +165,18 @@ export default function BlockNode({ data, selected }: NodeProps<BlockNodeData>) 
     // For AND/OR gates with variable inputs
     if ((blockType === 'AND' || blockType === 'OR') && 'minInputs' in config) {
       const inputCount = data.inputCount || config.minInputs
-      const inputs = []
+      const inputs: string[] = []
       for (let i = 0; i < inputCount; i++) {
         inputs.push(String.fromCharCode(97 + i)) // a, b, c, d...
       }
       return inputs
     }
     // For fixed input blocks
-    return config.inputs || []
+    return (config as any).inputs || []
   }
   
   const inputs = getInputs()
-  const outputs = config.outputs || []
+  const outputs = (config as any).outputs || []
   
   // Calculate handle spacing
   const inputSpacing = 100 / (inputs.length + 1)
@@ -192,7 +192,7 @@ export default function BlockNode({ data, selected }: NodeProps<BlockNodeData>) 
       `}
     >
       {/* Input handles - larger and more visible */}
-      {inputs.map((input, index) => (
+      {inputs.map((input: string, index: number) => (
         <Handle
           key={`input-${input}`}
           id={input}
@@ -217,13 +217,13 @@ export default function BlockNode({ data, selected }: NodeProps<BlockNodeData>) 
       <div className="text-center">
         <div className="text-2xl font-bold text-gray-800">{config.symbol}</div>
         <div className="text-xs text-gray-600 mt-1">{data.label}</div>
-        {config.description && (
-          <div className="text-xs text-gray-500 mt-1 italic">{config.description}</div>
+        {(config as any).description && (
+          <div className="text-xs text-gray-500 mt-1 italic">{(config as any).description}</div>
         )}
       </div>
       
       {/* Output handles - larger and more visible */}
-      {outputs.map((output, index) => (
+      {outputs.map((output: string, index: number) => (
         <Handle
           key={`output-${output}`}
           id={output}

--- a/petra-designer/src/nodes/MqttNode.tsx
+++ b/petra-designer/src/nodes/MqttNode.tsx
@@ -1,10 +1,10 @@
 // petra-designer/src/nodes/MqttNode.tsx
 import React from 'react'
-import { Handle, Position, type NodeProps } from '@xyflow/react'
+import { Handle, Position, type NodeProps, type Node } from '@xyflow/react'
 import type { MqttNodeData } from '@/types/nodes'
 import { FaWifi, FaExclamationTriangle } from 'react-icons/fa'
 
-export default function MqttNode({ data, selected }: NodeProps<MqttNodeData>) {
+export default function MqttNode({ data, selected }: NodeProps<Node<MqttNodeData>>) {
   const isConfigured = data.configured && data.brokerHost && data.brokerPort
   
   return (
@@ -97,7 +97,7 @@ export default function MqttNode({ data, selected }: NodeProps<MqttNodeData>) {
         {data.subscriptions && data.subscriptions.length > 0 && (
           <div className="text-xs">
             <div className="text-gray-500">Subscriptions:</div>
-            {data.subscriptions.slice(0, 2).map((sub, i) => (
+            {data.subscriptions.slice(0, 2).map((sub: { topic: string }, i: number) => (
               <div key={i} className="text-gray-600 font-mono truncate" title={sub.topic}>
                 {sub.topic}
               </div>

--- a/petra-designer/src/store/flowStore.ts
+++ b/petra-designer/src/store/flowStore.ts
@@ -38,6 +38,7 @@ interface FlowState {
   updateNode: (nodeId: string, data: any) => void
   updateNodeData: (nodeId: string, updates: any) => void
   deleteNode: (nodeId: string) => void
+  deleteEdge: (edgeId: string) => void
   deleteSelectedNode: () => void
   setSelectedNode: (node: Node | null) => void
   
@@ -170,7 +171,7 @@ function getDefaultNodeData(type: string, customData?: any): any {
     const config = BLOCK_CONFIGS[blockType]
     
     // Generate inputs based on block type
-    let inputs = []
+    let inputs: { name: string; type: string }[] = []
     if ((blockType === 'AND' || blockType === 'OR') && config?.maxInputs) {
       // Variable inputs for AND/OR
       const inputCount = customData.inputCount || config.defaultInputCount || 2
@@ -414,6 +415,13 @@ const useFlowStoreInternal = create<FlowState>()(
         nodes: get().nodes.filter((n) => n.id !== nodeId),
         edges: get().edges.filter((e) => e.source !== nodeId && e.target !== nodeId),
         selectedNode: get().selectedNode?.id === nodeId ? null : get().selectedNode,
+      })
+      saveHistory(get, set)
+    },
+
+    deleteEdge: (edgeId: string) => {
+      set({
+        edges: get().edges.filter(e => e.id !== edgeId),
       })
       saveHistory(get, set)
     },


### PR DESCRIPTION
## Summary
- add missing `deleteEdge` handler to flow store
- tighten types in flow store, nodes, and components
- update sidebar definitions for block metadata
- cast values in properties panel for React compliance

## Testing
- `npm run build`
- `cargo test --quiet` *(fails: field/struct errors)*

------
https://chatgpt.com/codex/tasks/task_e_6871df8aa3e4832c9682db7e8232f76f