### PR TITLE
Fix TypeScript safety for ISA-101 components

### DIFF
--- a/petra-designer/src/components/hmi/HMIDesigner.tsx
+++ b/petra-designer/src/components/hmi/HMIDesigner.tsx
@@ -1,6 +1,7 @@
-// @ts-nocheck
 import { useState, useEffect, useRef } from 'react'
 import { Stage, Layer, Rect, Line } from 'react-konva'
+import type { Stage as KonvaStage } from 'konva/lib/Stage'
+import type { HMIComponent, HMIComponentType } from '@/types/hmi'
 import { 
   FaBars, FaTimes, FaIndustry, FaChartLine, FaFont, FaShapes,
   FaPalette, FaEye, FaEyeSlash, FaLock, FaUnlock, FaTrash,
@@ -33,6 +34,9 @@ const ISA101Colors = {
   accent: '#0080FF',
   gridLine: '#D0D0D0',
   categoryHeader: '#D0D0D0',
+  running: '#00FF00',
+  stopped: '#808080',
+  alarmLow: '#FFFF00',
 }
 
 // Component categories following ISA-101 organization
@@ -232,19 +236,19 @@ const componentCategories = [
 
 export default function ISA101HMIDesigner() {
   const { connected, signals, subscribeSignal, unsubscribeSignal } = usePetra()
-  const [components, setComponents] = useState([])
-  const [selectedId, setSelectedId] = useState(null)
-  const [showGrid, setShowGrid] = useState(true)
-  const [gridSize, setGridSize] = useState(20)
-  const [snapToGrid, setSnapToGrid] = useState(true)
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
-  const [activeCategory, setActiveCategory] = useState(0)
-  const [stageSize, setStageSize] = useState({ width: 1200, height: 800 })
-  const [isDragging, setIsDragging] = useState(false)
-  const [showBindingPanel, setShowBindingPanel] = useState(false)
-  const [availableSignals, setAvailableSignals] = useState([])
-  const stageRef = useRef()
-  const draggedComponent = useRef(null)
+  const [components, setComponents] = useState<HMIComponent[]>([])
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [showGrid, setShowGrid] = useState<boolean>(true)
+  const [gridSize, setGridSize] = useState<number>(20)
+  const [snapToGrid, setSnapToGrid] = useState<boolean>(true)
+  const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(false)
+  const [activeCategory, setActiveCategory] = useState<number>(0)
+  const [stageSize, setStageSize] = useState<{ width: number; height: number }>({ width: 1200, height: 800 })
+  const [isDragging, setIsDragging] = useState<boolean>(false)
+  const [showBindingPanel, setShowBindingPanel] = useState<boolean>(false)
+  const [availableSignals, setAvailableSignals] = useState<string[]>([])
+  const stageRef = useRef<KonvaStage | null>(null)
+  const draggedComponent = useRef<HMIComponent | null>(null)
 
   // Update component properties based on signal bindings
   useEffect(() => {
@@ -311,7 +315,7 @@ export default function ISA101HMIDesigner() {
   }, [sidebarCollapsed])
 
   // Add component to canvas
-  const addComponent = (componentType) => {
+  const addComponent = (componentType: HMIComponentType) => {
     const category = componentCategories.find(cat => 
       cat.components.some(comp => comp.type === componentType)
     )
@@ -320,7 +324,7 @@ export default function ISA101HMIDesigner() {
     if (!componentDef) return
 
     // Component-specific default sizes
-    const getDefaultSize = (type) => {
+    const getDefaultSize = (type: HMIComponentType) => {
       switch (type) {
         case 'tank': return { width: 120, height: 150 }
         case 'mixer': return { width: 100, height: 120 }
@@ -335,7 +339,7 @@ export default function ISA101HMIDesigner() {
       }
     }
 
-    const newComponent = {
+    const newComponent: HMIComponent = {
       id: `${componentType}-${Date.now()}`,
       type: componentType,
       position: { x: 100, y: 100 },
@@ -355,7 +359,7 @@ export default function ISA101HMIDesigner() {
   }
 
   // Update component
-  const updateComponent = (id, updates) => {
+  const updateComponent = (id: string, updates: Partial<HMIComponent>) => {
     setComponents(components.map(comp => 
       comp.id === id ? { ...comp, ...updates } : comp
     ))
@@ -370,8 +374,8 @@ export default function ISA101HMIDesigner() {
   }
 
   // Render component based on type
-  const renderComponent = (component) => {
-    const commonProps = {
+  const renderComponent = (component: HMIComponent) => {
+    const commonProps: any = {
       x: component.position.x,
       y: component.position.y,
       width: component.size.width,
@@ -381,7 +385,7 @@ export default function ISA101HMIDesigner() {
       selected: component.id === selectedId,
       onClick: () => setSelectedId(component.id),
       draggable: !component.locked,
-      onDragEnd: (e) => {
+      onDragEnd: (e: any) => {
         const node = e.target
         let x = node.x()
         let y = node.y()
@@ -397,7 +401,7 @@ export default function ISA101HMIDesigner() {
           position: { x, y }
         })
       },
-      onDragStart: (e) => {
+      onDragStart: (e: any) => {
         e.target.moveToTop()
         setIsDragging(true)
       }
@@ -487,10 +491,10 @@ export default function ISA101HMIDesigner() {
                 
                 {activeCategory === idx && (
                   <div className="grid grid-cols-2 gap-1 p-2">
-                    {category.components.map(comp => (
+                      {category.components.map(comp => (
                       <button
                         key={comp.type}
-                        onClick={() => addComponent(comp.type)}
+                        onClick={() => addComponent(comp.type as HMIComponentType)}
                         className="p-2 text-xs border rounded hover:bg-gray-200 flex flex-col items-center gap-1"
                         style={{ 
                           backgroundColor: ISA101Colors.buttonBg,

--- a/petra-designer/src/components/hmi/ISA101WaterPlantDemo.tsx
+++ b/petra-designer/src/components/hmi/ISA101WaterPlantDemo.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // src/components/hmi/WaterPlantDemo.tsx
 
 import { useState, useEffect, useCallback } from 'react'
@@ -352,7 +351,7 @@ export default function WaterPlantPetraDemo() {
                   <span>Setpoint:</span>
                   <input
                     type="number"
-                    value={signals[`pump${num}SetpointFlow` as keyof typeof signals]}
+                    value={Number(signals[`pump${num}SetpointFlow` as keyof typeof signals])}
                     onChange={(e) => updateSetpoint(`pump${num}.setpoint_flow`, parseInt(e.target.value))}
                     className="w-20 px-2 py-1 border rounded text-right"
                     min="0"
@@ -500,7 +499,6 @@ export default function WaterPlantPetraDemo() {
                   stroke: '#374151',
                   strokeWidth: 2
                 }}
-                bindings={[]}
               />
               {/* Tank annotations */}
               <Text
@@ -573,7 +571,6 @@ export default function WaterPlantPetraDemo() {
                   stroke: '#374151',
                   strokeWidth: 2
                 }}
-                bindings={[]}
               />
               <Text
                 x={500}
@@ -627,7 +624,6 @@ export default function WaterPlantPetraDemo() {
                     stroke: signals[`pump${num}IsLead` as keyof typeof signals] ? '#f59e0b' : '#374151',
                     strokeWidth: signals[`pump${num}IsLead` as keyof typeof signals] ? 3 : 2
                   }}
-                  bindings={[]}
                 />
                 <Text
                   x={500}
@@ -850,7 +846,6 @@ export default function WaterPlantPetraDemo() {
                   stroke: '#4338ca',
                   strokeWidth: 2
                 }}
-                bindings={[]}
               />
               <ISA101TankComponent
                 x={100}
@@ -874,7 +869,6 @@ export default function WaterPlantPetraDemo() {
                   stroke: '#4338ca',
                   strokeWidth: 2
                 }}
-                bindings={[]}
               />
             </Group>
             

--- a/petra-designer/src/components/hmi/components/ISA101ButtonComponent.tsx
+++ b/petra-designer/src/components/hmi/components/ISA101ButtonComponent.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Group, Rect, Text } from 'react-konva'
 import { useState, useRef } from 'react'
 

--- a/petra-designer/src/components/hmi/components/ISA101ComponentRenderer.tsx
+++ b/petra-designer/src/components/hmi/components/ISA101ComponentRenderer.tsx
@@ -1,5 +1,5 @@
-// @ts-nocheck
 import React from 'react'
+import type { HMIComponent } from '@/types/hmi'
 import ISA101TankComponent from './ISA101TankComponent'
 import ISA101PumpComponent from './ISA101PumpComponent'
 import ISA101ValveComponent from './ISA101ValveComponent'
@@ -16,10 +16,10 @@ import ISA101PipeComponent from './ISA101PipeComponent'
 import ISA101ShapeComponent from './ISA101ShapeComponent'
 
 interface ISA101ComponentRendererProps {
-  component: any
+  component: HMIComponent
   isSelected: boolean
   onSelect: () => void
-  onUpdate: (updates: any) => void
+  onUpdate: (updates: Partial<HMIComponent>) => void
 }
 
 export default function ISA101ComponentRenderer({

--- a/petra-designer/src/components/hmi/components/ISA101ConveyorComponent.tsx
+++ b/petra-designer/src/components/hmi/components/ISA101ConveyorComponent.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import ConveyorComponent from './ConveyorComponent'
 
 export default function ISA101ConveyorComponent(props: any) {

--- a/petra-designer/src/components/hmi/components/ISA101GaugeComponent.tsx
+++ b/petra-designer/src/components/hmi/components/ISA101GaugeComponent.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Group, Circle, Line, Text, Shape, Rect } from 'react-konva'
 import { useRef } from 'react'
 
@@ -22,20 +21,22 @@ interface ISA101GaugeProps {
   width: number
   height: number
   properties: {
-    tagName: string
-    currentValue: number
-    units: string
-    minValue: number
-    maxValue: number
+    tagName?: string
+    currentValue?: number
+    units?: string
+    minValue?: number
+    maxValue?: number
     alarmHigh?: number
     alarmLow?: number
     setpoint?: number
     showDigitalValue?: boolean
     gaugeType?: 'pressure' | 'temperature' | 'flow' | 'level'
     showTrend?: boolean
+    [key: string]: any
   }
   style?: {
     lineWidth?: number
+    [key: string]: any
   }
   selected?: boolean
   onClick?: () => void
@@ -65,15 +66,22 @@ export default function ISA101GaugeComponent({
   const centerX = width / 2
   const centerY = height / 2
 
+  const {
+    minValue = 0,
+    maxValue = 100,
+    currentValue = 0,
+    units = '',
+  } = properties
+
   // Calculate angles
   const startAngle = -135 // Start at 225 degrees (lower left)
   const endAngle = 135   // End at 315 degrees (lower right)
   const angleRange = endAngle - startAngle
 
   // Calculate value position
-  const valueRange = properties.maxValue - properties.minValue
+  const valueRange = maxValue - minValue
   const normalizedValue = Math.max(0, Math.min(1, 
-    (properties.currentValue - properties.minValue) / valueRange
+    (currentValue - minValue) / valueRange
   ))
   const valueAngle = startAngle + (angleRange * normalizedValue)
 
@@ -88,8 +96,8 @@ export default function ISA101GaugeComponent({
 
   // Determine if value is in alarm
   const isInAlarm = () => {
-    if (properties.alarmHigh && properties.currentValue >= properties.alarmHigh) return true
-    if (properties.alarmLow && properties.currentValue <= properties.alarmLow) return true
+    if (properties.alarmHigh !== undefined && currentValue >= properties.alarmHigh) return true
+    if (properties.alarmLow !== undefined && currentValue <= properties.alarmLow) return true
     return false
   }
 
@@ -101,7 +109,7 @@ export default function ISA101GaugeComponent({
 
     for (let i = 0; i <= majorTicks; i++) {
       const angle = startAngle + (angleRange * i / majorTicks)
-      const value = properties.minValue + (valueRange * i / majorTicks)
+      const value = minValue + (valueRange * i / majorTicks)
       const outer = getXY(angle, radius)
       const inner = getXY(angle, radius - 10)
       const label = getXY(angle, radius - 20)
@@ -210,10 +218,10 @@ export default function ISA101GaugeComponent({
       />
 
       {/* Alarm zones */}
-      {properties.alarmHigh && (
+      {properties.alarmHigh !== undefined && (
         <Shape
           sceneFunc={(ctx, shape) => {
-            const alarmNormalized = (properties.alarmHigh - properties.minValue) / valueRange
+            const alarmNormalized = (properties.alarmHigh! - minValue) / valueRange
             const alarmStartAngle = startAngle + (angleRange * alarmNormalized)
             ctx.beginPath()
             ctx.arc(
@@ -232,10 +240,10 @@ export default function ISA101GaugeComponent({
         />
       )}
 
-      {properties.alarmLow && (
+      {properties.alarmLow !== undefined && (
         <Shape
           sceneFunc={(ctx, shape) => {
-            const alarmNormalized = (properties.alarmLow - properties.minValue) / valueRange
+            const alarmNormalized = (properties.alarmLow! - minValue) / valueRange
             const alarmEndAngle = startAngle + (angleRange * alarmNormalized)
             ctx.beginPath()
             ctx.arc(
@@ -260,7 +268,7 @@ export default function ISA101GaugeComponent({
       {/* Setpoint indicator */}
       {properties.setpoint !== undefined && (
         (() => {
-          const setpointNormalized = (properties.setpoint - properties.minValue) / valueRange
+          const setpointNormalized = (properties.setpoint! - minValue) / valueRange
           const setpointAngle = startAngle + (angleRange * setpointNormalized)
           const sp = getXY(setpointAngle, radius + 8)
           return (
@@ -326,7 +334,7 @@ export default function ISA101GaugeComponent({
             x={0}
             y={4}
             width={80}
-            text={`${properties.currentValue.toFixed(1)} ${properties.units}`}
+            text={`${currentValue.toFixed(1)} ${units}`}
             fontSize={14}
             fontStyle="bold"
             fill={isInAlarm() ? ISA101Colors.needleAlarm : ISA101Colors.processValue}

--- a/petra-designer/src/components/hmi/components/ISA101HeatExchangerComponent.tsx
+++ b/petra-designer/src/components/hmi/components/ISA101HeatExchangerComponent.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Group, Rect, Line } from 'react-konva'
 
 export default function ISA101HeatExchangerComponent({ x, y, width, height, properties, ...props }: any) {

--- a/petra-designer/src/components/hmi/components/ISA101IndicatorComponent.tsx
+++ b/petra-designer/src/components/hmi/components/ISA101IndicatorComponent.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Group, Circle, Rect, Text } from 'react-konva'
 import { useRef, useState, useEffect } from 'react'
 

--- a/petra-designer/src/components/hmi/components/ISA101MixerComponent.tsx
+++ b/petra-designer/src/components/hmi/components/ISA101MixerComponent.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useEffect, useRef } from 'react'
 import { Group, Circle, Line, Path, Text, Rect, Shape } from 'react-konva'
 

--- a/petra-designer/src/components/hmi/components/ISA101MotorComponent.tsx
+++ b/petra-designer/src/components/hmi/components/ISA101MotorComponent.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Group, Circle, Text, Rect } from 'react-konva'
 import { useRef } from 'react'
 
@@ -19,7 +18,7 @@ interface ISA101MotorProps {
   width: number
   height: number
   properties: {
-    tagName: string
+    tagName?: string
     running: boolean
     speed?: number
     fault?: boolean

--- a/petra-designer/src/components/hmi/components/ISA101PipeComponent.tsx
+++ b/petra-designer/src/components/hmi/components/ISA101PipeComponent.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Group, Line, Rect, Arrow } from 'react-konva'
 import { useRef, useEffect, useState } from 'react'
 

--- a/petra-designer/src/components/hmi/components/ISA101PumpComponent.tsx
+++ b/petra-designer/src/components/hmi/components/ISA101PumpComponent.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useEffect, useRef, useState } from 'react'
 import { Group, Circle, Line, Text, Rect, Shape, Path } from 'react-konva'
 
@@ -21,8 +20,8 @@ interface ISA101PumpProps {
   width: number
   height: number
   properties: {
-    tagName: string
-    status: 'running' | 'stopped' | 'fault' | 'transitioning'
+    tagName?: string
+    status?: 'running' | 'stopped' | 'fault' | 'transitioning'
     flowRate?: number
     flowUnits?: string
     dischargePressure?: number
@@ -33,9 +32,11 @@ interface ISA101PumpProps {
     showDetailedStatus?: boolean
     showFlowDirection?: boolean
     pumpType?: 'centrifugal' | 'positive-displacement'
+    [key: string]: any
   }
   style?: {
     lineWidth?: number
+    [key: string]: any
   }
   selected?: boolean
   onClick?: () => void

--- a/petra-designer/src/components/hmi/components/ISA101ShapeComponent.tsx
+++ b/petra-designer/src/components/hmi/components/ISA101ShapeComponent.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Group, Rect, Circle, Line, RegularPolygon } from 'react-konva'
 import { useRef } from 'react'
 
@@ -14,12 +13,13 @@ interface ISA101ShapeProps {
   width: number
   height: number
   properties: {
-    shapeType: 'rectangle' | 'circle' | 'triangle' | 'hexagon' | 'line'
+    shapeType?: 'rectangle' | 'circle' | 'triangle' | 'hexagon' | 'line'
     fill?: string
     stroke?: string
     strokeWidth?: number
     cornerRadius?: number
     opacity?: number
+    [key: string]: any
   }
   style?: any
   selected?: boolean

--- a/petra-designer/src/components/hmi/components/ISA101TankComponent.tsx
+++ b/petra-designer/src/components/hmi/components/ISA101TankComponent.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useEffect, useState, useRef } from 'react'
 import { Group, Rect, Shape, Text, Line } from 'react-konva'
 
@@ -38,9 +37,9 @@ interface ISA101TankProps {
   width: number
   height: number
   properties: {
-    tagName: string
+    tagName?: string
     currentLevel: number
-    levelUnits: string
+    levelUnits?: string
     maxLevel: number
     minLevel: number
     criticalHigh?: number
@@ -57,9 +56,11 @@ interface ISA101TankProps {
     inletValveOpen?: boolean
     outletValveOpen?: boolean
     agitatorRunning?: boolean
+    [key: string]: any
   }
   style?: {
     lineWidth?: number
+    [key: string]: any
   }
   selected?: boolean
   onContextMenu?: (e: any) => void

--- a/petra-designer/src/components/hmi/components/ISA101TextComponent.tsx
+++ b/petra-designer/src/components/hmi/components/ISA101TextComponent.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { Group, Text, Rect } from 'react-konva'
 import { useRef } from 'react'
 

--- a/petra-designer/src/components/hmi/components/ISA101TrendComponent.tsx
+++ b/petra-designer/src/components/hmi/components/ISA101TrendComponent.tsx
@@ -1,5 +1,4 @@
-// @ts-nocheck
-import TrendComponent from './TrendComponent'
+import TrendComponent from './ISA101Trend'
 
 export default function ISA101TrendComponent(props: any) {
   return <TrendComponent {...props} />

--- a/petra-designer/src/components/hmi/components/ISA101ValveComponent.tsx
+++ b/petra-designer/src/components/hmi/components/ISA101ValveComponent.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useEffect, useState, useRef } from 'react'
 import { Group, Line, Shape, Text, Rect, Circle } from 'react-konva'
 
@@ -22,18 +21,20 @@ interface ISA101ValveProps {
   width: number
   height: number
   properties: {
-    tagName: string
-    position: number // 0-100%
-    status: 'open' | 'closed' | 'transitioning' | 'fault'
+    tagName?: string
+    position?: number // 0-100%
+    status?: 'open' | 'closed' | 'transitioning' | 'fault'
     valveType?: 'gate' | 'ball' | 'butterfly' | 'control'
     controlMode?: 'auto' | 'manual' | 'cascade'
     interlocked?: boolean
     showPosition?: boolean
     orientation?: 'horizontal' | 'vertical'
     failPosition?: 'open' | 'closed' | 'last'
+    [key: string]: any
   }
   style?: {
     lineWidth?: number
+    [key: string]: any
   }
   selected?: boolean
   onClick?: () => void
@@ -61,6 +62,7 @@ export default function ISA101ValveComponent({
   const [isAnimating, setIsAnimating] = useState(false)
   const animationRef = useRef<any>()
   const groupRef = useRef<any>()
+  const position = properties.position ?? 0
 
   // Determine valve color based on status
   const getValveColor = () => {
@@ -133,9 +135,9 @@ export default function ISA101ValveComponent({
               fill={getValveColor()}
               stroke={ISA101Colors.equipmentOutline}
               strokeWidth={1}
-              rotation={isVertical ? 
-                (properties.position > 50 ? 0 : 90) : 
-                (properties.position > 50 ? 90 : 0)}
+              rotation={isVertical ?
+                (position > 50 ? 0 : 90) :
+                (position > 50 ? 90 : 0)}
             />
           </Group>
         )
@@ -159,8 +161,8 @@ export default function ISA101ValveComponent({
               strokeWidth={valveSize / 8}
               lineCap="round"
               rotation={isVertical ? 
-                (90 - properties.position * 0.9) : 
-                (properties.position * 0.9)}
+                (90 - position * 0.9) :
+                (position * 0.9)}
             />
           </Group>
         )
@@ -194,7 +196,7 @@ export default function ISA101ValveComponent({
             />
             <Circle
               x={0}
-              y={-valveSize + (properties.position / 100) * (valveSize / 2)}
+              y={-valveSize + (position / 100) * (valveSize / 2)}
               radius={valveSize / 8}
               fill={getValveColor()}
               stroke={ISA101Colors.equipmentOutline}
@@ -225,7 +227,7 @@ export default function ISA101ValveComponent({
             {/* Gate position */}
             <Rect
               x={-valveSize / 3}
-              y={-valveSize * 0.6 + (1 - properties.position / 100) * valveSize * 1.2}
+              y={-valveSize * 0.6 + (1 - position / 100) * valveSize * 1.2}
               width={valveSize * 2 / 3}
               height={valveSize * 0.2}
               fill={getValveColor()}
@@ -332,7 +334,7 @@ export default function ISA101ValveComponent({
             x={width / 2 - 30}
             y={2}
             width={60}
-            text={`${properties.position.toFixed(0)}%`}
+            text={`${position.toFixed(0)}%`}
             fontSize={12}
             fontStyle="bold"
             fill={ISA101Colors.processValue}

--- a/petra-designer/src/types/hmi.ts
+++ b/petra-designer/src/types/hmi.ts
@@ -18,6 +18,7 @@ export type HMIComponentType =
   | 'heat-exchanger'
   | 'conveyor'
   | 'mixer'
+  | 'title'
   
 export interface ConnectionInfo {
   status: 'connected' | 'disconnected' | 'connecting' | 'error'

--- a/petra-designer/src/types/index.ts
+++ b/petra-designer/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './hmi'
+export * from './nodes'


### PR DESCRIPTION
## Summary
- remove `@ts-nocheck` directives from HMI designer and ISA‑101 components
- tighten types for designer state and component props
- allow optional/extra properties for ISA‑101 components
- add missing color constants
- create `src/types/index.ts` for type re‑exports

## Testing
- `npx tsc --noEmit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68728cbb5530832ca49fc6b8bb5d1022