### PR TITLE
Add vitest setup and tests

### DIFF
--- a/petra-designer/package.json
+++ b/petra-designer/package.json
@@ -8,31 +8,35 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "lint": "eslint \"src/**/*.{ts,tsx}\" --report-unused-disable-directives --max-warnings 0"
+    "lint": "eslint \"src/**/*.{ts,tsx}\" --report-unused-disable-directives --max-warnings 0",
+    "test": "vitest run"
   },
   "dependencies": {
     "@xyflow/react": "latest",
-    "reactflow": "^11.10.1",
-    "recharts": "^2.9.3",
+    "konva": "^9.3.0",
     "lucide-react": "^0.292.0",
+    "nanoid": "^5.0.4",
+    "prismjs": "^1.29.0",
     "react": "^18.2.0",
+    "react-color": "^2.19.3",
     "react-dom": "^18.2.0",
-    "zustand": "^4.5.0",
-    "yaml": "^2.3.4",
     "react-hot-toast": "^2.4.1",
     "react-icons": "^5.0.1",
-    "prismjs": "^1.29.0",
-    "react-simple-code-editor": "^0.13.1",
-    "nanoid": "^5.0.4",
     "react-konva": "^18.2.10",
-    "konva": "^9.3.0",
+    "react-simple-code-editor": "^0.13.1",
+    "reactflow": "^11.10.1",
+    "recharts": "^2.9.3",
     "use-image": "^1.1.1",
-    "react-color": "^2.19.3"
+    "yaml": "^2.3.4",
+    "zustand": "^4.5.0"
   },
   "devDependencies": {
-    "@types/react": "^18.2.66",
-    "@types/react-dom": "^18.2.22",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
     "@types/prismjs": "^1.26.3",
+    "@types/react": "^18.2.66",
+    "@types/react-color": "^3.0.13",
+    "@types/react-dom": "^18.2.22",
     "@typescript-eslint/eslint-plugin": "^7.2.0",
     "@typescript-eslint/parser": "^7.2.0",
     "@vitejs/plugin-react": "^4.2.1",
@@ -40,10 +44,11 @@
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.6",
+    "jsdom": "^26.1.0",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.2.2",
     "vite": "^5.2.0",
-    "@types/react-color": "^3.0.13"
+    "vitest": "^3.2.4"
   }
 }

--- a/petra-designer/src/__tests__/integration.test.tsx
+++ b/petra-designer/src/__tests__/integration.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { generateYaml } from '../utils/yamlGenerator'
+import { parseYamlConfig } from '../utils/yamlParser'
+import { validateConnection } from '../utils/validation'
+import { useFlowStore } from '../store/flowStore'
+import type { Node, Edge, Connection } from '@xyflow/react'
+
+function makeSignal(id: string): Node {
+  return { id, type: 'signal', position: { x:0, y:0 }, data: { label:id, signalName:id, signalType:'float', initial:0, mode:'write' } }
+}
+
+function makeBlock(id: string): Node {
+  return { id, type: 'block', position: { x:0, y:0 }, data: { label:id, blockType:'ADD', inputs:[{name:'a', type:'float'}], outputs:[{name:'out', type:'float'}] } }
+}
+
+describe('integration workflow', () => {
+  it('create flow -> export -> import', () => {
+    const sig = makeSignal('sig1')
+    const block = makeBlock('b1')
+    const edges: Edge[] = [{ id:'e1', source:sig.id, target:block.id, targetHandle:'a' } as any]
+    const yaml = generateYaml([sig, block], edges)
+    const parsed = parseYamlConfig(yaml)
+    expect(parsed.nodes.length).toBe(2)
+    expect(parsed.edges.length).toBe(1)
+  })
+
+  it('drag and drop updates node position', () => {
+    const node = makeSignal('drag')
+    useFlowStore.setState({ nodes:[node], edges:[], selectedNode:null })
+    useFlowStore.getState().onNodesChange([{ id: node.id, type:'position', position:{ x:10, y:20 } }] as any)
+    const updated = useFlowStore.getState().nodes.find(n => n.id===node.id)
+    expect(updated?.position).toEqual({ x:10, y:20 })
+  })
+
+  it('connection validation prevents duplicates', () => {
+    const n1 = makeSignal('s1')
+    const n2 = makeBlock('b1')
+    const edges: Edge[] = []
+    const conn: Connection = { source:n1.id, target:n2.id, sourceHandle:undefined, targetHandle:'a' }
+    const valid = validateConnection(conn, [n1,n2], edges)
+    expect(valid.valid).toBe(true)
+    edges.push({ id:'e1', source:n1.id, target:n2.id, targetHandle:'a' } as any)
+    const second = validateConnection(conn, [n1,n2], edges)
+    expect(second.valid).toBe(false)
+  })
+})

--- a/petra-designer/src/components/__tests__/PropertiesPanel.test.tsx
+++ b/petra-designer/src/components/__tests__/PropertiesPanel.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import PropertiesPanel from '../PropertiesPanel'
+import { useFlowStore } from '@/store/flowStore'
+import { vi } from 'vitest'
+
+function makeSignal() {
+  return { id:'s1', type:'signal', position:{x:0,y:0}, data:{ label:'sig', signalName:'sig', signalType:'bool', initial:false, mode:'write' } }
+}
+
+describe('PropertiesPanel', () => {
+  it('updates label via updateNodeData', () => {
+    const node = makeSignal()
+    const updateNodeData = vi.fn()
+    useFlowStore.setState({ nodes:[node], edges:[], selectedNode:node, updateNodeData })
+
+    render(<PropertiesPanel />)
+    const input = screen.getAllByDisplayValue('sig')[0] as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'new' } })
+    expect(updateNodeData).toHaveBeenCalledWith(node.id, { label: 'new' })
+  })
+})

--- a/petra-designer/src/components/__tests__/Toolbar.test.tsx
+++ b/petra-designer/src/components/__tests__/Toolbar.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import Toolbar from '../Toolbar'
+import { useOptimizedFlowStore } from '@/store/optimizedFlowStore'
+import toast from 'react-hot-toast'
+import { vi } from 'vitest'
+
+vi.mock('react-hot-toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }))
+
+const mockedToast = toast as unknown as { success: any; error: any }
+
+describe('Toolbar interactions', () => {
+  beforeEach(() => {
+    useOptimizedFlowStore.setState({ nodes: [], edges: [], selectedNode: null })
+    mockedToast.success.mockClear()
+    mockedToast.error.mockClear()
+  })
+
+  it('validates logic on button click', () => {
+    const validateLogic = vi.fn(() => ({ valid: true, nodeCount: 1, connectionCount: 0, errors: [] }))
+    useOptimizedFlowStore.setState({ validateLogic })
+
+    render(<Toolbar />)
+    fireEvent.click(screen.getByTitle('Validate Logic'))
+
+    expect(validateLogic).toHaveBeenCalled()
+    expect(mockedToast.success).toHaveBeenCalled()
+  })
+
+  it('deletes selected block', () => {
+    const deleteSelectedNode = vi.fn()
+    useOptimizedFlowStore.setState({ selectedNode: { id: '1' } as any, deleteSelectedNode })
+
+    render(<Toolbar />)
+    fireEvent.click(screen.getByTitle('Delete Selected Block'))
+
+    expect(deleteSelectedNode).toHaveBeenCalled()
+  })
+})

--- a/petra-designer/src/components/__tests__/YamlPreview.test.tsx
+++ b/petra-designer/src/components/__tests__/YamlPreview.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react'
+import YamlPreview from '../YamlPreview'
+import { useOptimizedFlowStore } from '@/store/optimizedFlowStore'
+
+function makeSignal() {
+  return { id:'s1', type:'signal', position:{x:0,y:0}, data:{ label:'s1', signalName:'s1', signalType:'float', initial:0, mode:'write' } }
+}
+
+describe('YamlPreview component', () => {
+  it('renders YAML from store', () => {
+    useOptimizedFlowStore.setState({ nodes:[makeSignal()], edges:[] })
+    render(<YamlPreview />)
+    expect(screen.getByText('YAML Preview')).toBeInTheDocument()
+    expect(screen.getByText(/signals:/)).toBeInTheDocument()
+  })
+})

--- a/petra-designer/src/test/setup.ts
+++ b/petra-designer/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/petra-designer/src/utils/__tests__/yamlGenerator.test.ts
+++ b/petra-designer/src/utils/__tests__/yamlGenerator.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import { generateYaml, validateYamlConfig } from '../yamlGenerator'
+import type { Node, Edge } from '@xyflow/react'
+import type { SignalNodeData, BlockNodeData, MqttNodeData, S7NodeData } from '@/types/nodes'
+
+function makeSignal(id: string, data: Partial<SignalNodeData> = {}): Node {
+  return {
+    id,
+    type: 'signal',
+    position: { x: 0, y: 0 },
+    data: {
+      label: data.label ?? id,
+      signalName: data.signalName ?? id,
+      signalType: data.signalType ?? 'float',
+      initial: data.initial ?? 0,
+      mode: data.mode ?? 'write'
+    }
+  }
+}
+
+function makeBlock(id: string, blockType: string, inputs: string[], outputs: string[]): Node {
+  return {
+    id,
+    type: 'block',
+    position: { x: 0, y: 0 },
+    data: {
+      label: id,
+      blockType,
+      inputs: inputs.map(name => ({ name, type: 'float' })),
+      outputs: outputs.map(name => ({ name, type: 'float' }))
+    }
+  }
+}
+
+describe('generateYaml', () => {
+  it('Empty flow generates valid YAML', () => {
+    const yaml = generateYaml([], [])
+    const res = validateYamlConfig(yaml)
+    expect(res.valid).toBe(true)
+    expect(yaml).toContain('signals: []')
+    expect(yaml).toContain('blocks: []')
+  })
+
+  it('Signal nodes convert correctly', () => {
+    const nodes: Node[] = [makeSignal('sig1', { signalType: 'int' })]
+    const yaml = generateYaml(nodes, [])
+    expect(yaml).toMatch(/name: sig1/)
+    expect(yaml).toMatch(/type: int/)
+    expect(validateYamlConfig(yaml).valid).toBe(true)
+  })
+
+  it('Block nodes with connections', () => {
+    const sig = makeSignal('input')
+    const block = makeBlock('b1', 'ADD', ['a', 'b'], ['out'])
+    const nodes = [sig, block]
+    const edges: Edge[] = [
+      { id: 'e1', source: sig.id, target: block.id, targetHandle: 'a' },
+      { id: 'e2', source: block.id, sourceHandle: 'out', target: sig.id }
+    ] as any
+    const yaml = generateYaml(nodes, edges)
+    expect(yaml).toMatch(/blocks:/)
+    expect(yaml).toMatch(/inputs:/)
+    expect(validateYamlConfig(yaml).valid).toBe(true)
+  })
+
+  it('Protocol nodes (MQTT, S7)', () => {
+    const mqttNode: Node = {
+      id: 'mqtt1',
+      type: 'mqtt',
+      position: { x: 0, y: 0 },
+      data: {
+        label: 'mqtt',
+        configured: true,
+        brokerHost: 'localhost',
+        brokerPort: 1883,
+        clientId: 'client',
+        topicPrefix: 'petra',
+        mode: 'read',
+        publishOnChange: false
+      } as MqttNodeData
+    }
+    const s7Node: Node = {
+      id: 's7_1',
+      type: 's7',
+      position: { x: 0, y: 0 },
+      data: {
+        label: 's7',
+        configured: true,
+        ip: '192.168.0.1',
+        rack: 0,
+        slot: 1,
+        area: 'DB',
+        dbNumber: 1,
+        address: 0,
+        dataType: 'int',
+        direction: 'read',
+        signal: 'sig'
+      } as S7NodeData
+    }
+    const yaml = generateYaml([mqttNode, s7Node], [])
+    expect(yaml).toMatch(/mqtt:/)
+    expect(yaml).toMatch(/s7:/)
+    expect(validateYamlConfig(yaml).valid).toBe(true)
+  })
+
+  it('Edge cases and error handling', () => {
+    // invalid yaml should return errors
+    const res = validateYamlConfig('bad: [yaml')
+    expect(res.valid).toBe(false)
+    expect(res.errors.length).toBeGreaterThan(0)
+  })
+})

--- a/petra-designer/vite.config.ts
+++ b/petra-designer/vite.config.ts
@@ -16,4 +16,9 @@ export default defineConfig({
   optimizeDeps: {
     include: ['@xyflow/react'],
   },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/test/setup.ts'
+  },
 })


### PR DESCRIPTION
## Summary
- add vitest and react testing libraries
- configure vitest in vite.config
- create unit tests for yaml generator
- add component tests for Toolbar, YamlPreview and PropertiesPanel
- add integration tests covering flow export/import and drag/drop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872b0916d48832cbbdd31cb9754c519